### PR TITLE
Add rccl install step for ROCm5.7 wheels

### DIFF
--- a/common/install_rccl.sh
+++ b/common/install_rccl.sh
@@ -1,0 +1,4 @@
+yum remove -y rccl
+
+yum install -y https://repo.radeon.com/rocm/manylinux/rocm-rel-5.7/.private_rccl_5.7/rccl-2.17.1-e896f0d.el7.x86_64.rpm
+yum install -y https://repo.radeon.com/rocm/manylinux/rocm-rel-5.7/.private_rccl_5.7/rccl-devel-2.17.1-e896f0d.el7.x86_64.rpm

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -174,3 +174,6 @@ RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
 # Do not install miopen from source for ROCm fork until an env var is introduced to control the behavior
 #ADD ./common/install_miopen.sh install_miopen.sh
 #RUN bash ./install_miopen.sh ${ROCM_VERSION} && rm install_miopen.sh
+# Install rccl from package with fixes for ROCm5.7
+ADD ./common/install_rccl.sh install_rccl.sh
+RUN bash ./install_rccl.sh && rm install_rccl.sh


### PR DESCRIPTION
Adds a step to install a RCCL package built with RCCL [PR 883](https://github.com/ROCmSoftwarePlatform/rccl/pull/883) cherry-picked on top of ROCm5.7 RCCL.

Tested via:
release/1.10.1: http://rocm-ci.amd.com/view/Release-5.7/job/pytorch-pipeline-manylinux-wheels_rel-5.7/19/
release/1.13: http://rocm-ci.amd.com/view/Release-5.7/job/pytorch-pipeline-manylinux-wheels_rel-5.7/18/
release/2.0: http://rocm-ci.amd.com/view/Release-5.7/job/pytorch-pipeline-manylinux-wheels_rel-5.7/17/