### PR TITLE
Changes to enable manylinux2_28 wheels for ROCm

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -71,7 +71,7 @@ else
 
     # Use case CUDA_VISIBLE_DEVICES: https://github.com/pytorch/pytorch/issues/128819
     if [[ ${MATRIX_GPU_ARCH_TYPE} == 'cuda' ]]; then
-        python3 -c "import torch;import os;print(torch.cuda.device_count(), torch.__version__);os.environ['CUDA_VISIBLE_DEVICES']='0';print(torch.empty(2, device='cuda'))"
+        python -c "import torch;import os;print(torch.cuda.device_count(), torch.__version__);os.environ['CUDA_VISIBLE_DEVICES']='0';print(torch.empty(2, device='cuda'))"
     fi
 
     # this is optional step

--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -27,12 +27,6 @@ else
 fi
 ROCM_INT=$(($ROCM_VERSION_MAJOR * 10000 + $ROCM_VERSION_MINOR * 100 + $ROCM_VERSION_PATCH))
 
-# Install custom MIOpen + COMgr for ROCm >= 4.0.1
-if [[ $ROCM_INT -lt 40001 ]]; then
-    echo "ROCm version < 4.0.1; will not install custom MIOpen"
-    exit 0
-fi
-
 # Function to retry functions that sometimes timeout or have flaky failures
 retry () {
     $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
@@ -68,28 +62,6 @@ elif [[ $ROCM_INT -ge 60100 ]] && [[ $ROCM_INT -lt 60200 ]]; then
 elif [[ $ROCM_INT -ge 60000 ]] && [[ $ROCM_INT -lt 60100 ]]; then
     echo "ROCm 6.0 MIOpen does not need any patches, do not build from source"
     exit 0
-elif [[ $ROCM_INT -ge 50700 ]] && [[ $ROCM_INT -lt 60000 ]]; then
-    echo "ROCm 5.7 MIOpen does not need any patches, do not build from source"
-    exit 0
-elif [[ $ROCM_INT -ge 50600 ]] && [[ $ROCM_INT -lt 50700 ]]; then
-    MIOPEN_BRANCH="release/rocm-rel-5.6-staging"
-elif [[ $ROCM_INT -ge 50500 ]] && [[ $ROCM_INT -lt 50600 ]]; then
-    MIOPEN_BRANCH="release/rocm-rel-5.5-gfx11"
-elif [[ $ROCM_INT -ge 50400 ]] && [[ $ROCM_INT -lt 50500 ]]; then
-    MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36 -DMIOPEN_USE_MLIR=Off"
-    MIOPEN_BRANCH="release/rocm-rel-5.4-staging"
-elif [[ $ROCM_INT -ge 50300 ]] && [[ $ROCM_INT -lt 50400 ]]; then
-    MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36 -DMIOPEN_USE_MLIR=Off"
-    MIOPEN_BRANCH="release/rocm-rel-5.3-staging"
-elif [[ $ROCM_INT -ge 50200 ]] && [[ $ROCM_INT -lt 50300 ]]; then
-    MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36 -DMIOPEN_USE_MLIR=Off"
-    MIOPEN_BRANCH="release/rocm-rel-5.2-staging"
-elif [[ $ROCM_INT -ge 50100 ]] && [[ $ROCM_INT -lt 50200 ]]; then
-    MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36"
-    MIOPEN_BRANCH="release/rocm-rel-5.1-staging"
-elif [[ $ROCM_INT -ge 50000 ]] && [[ $ROCM_INT -lt 50100 ]]; then
-    MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36"
-    MIOPEN_BRANCH="release/rocm-rel-5.0-staging"
 else
     echo "Unhandled ROCM_VERSION ${ROCM_VERSION}"
     exit 1
@@ -106,14 +78,8 @@ git clone https://github.com/ROCm/MIOpen -b ${MIOPEN_BRANCH}
 pushd MIOpen
 # remove .git to save disk space since CI runner was running out
 rm -rf .git
-# Don't build MLIR to save docker build time
-# since we are disabling MLIR backend for MIOpen anyway
-if [[ $ROCM_INT -ge 50400 ]] && [[ $ROCM_INT -lt 50500 ]]; then
-    sed -i '/rocMLIR/d' requirements.txt
-elif [[ $ROCM_INT -ge 50200 ]] && [[ $ROCM_INT -lt 50400 ]]; then
-    sed -i '/llvm-project-mlir/d' requirements.txt
-fi
-## MIOpen minimum requirements
+## MIOpen minimum requirements; don't rebuild CK as it's already installed with ROCm
+sed -i '/composable_kernel/d' requirements.txt
 cmake -P install_deps.cmake --minimum
 
 # clean up since CI runner was running out of disk space
@@ -129,7 +95,7 @@ cd build
 PKG_CONFIG_PATH=/usr/local/lib/pkgconfig CXX=${ROCM_INSTALL_PATH}/llvm/bin/clang++ cmake .. \
     ${MIOPEN_CMAKE_COMMON_FLAGS} \
     ${MIOPEN_CMAKE_DB_FLAGS} \
-    -DCMAKE_PREFIX_PATH="${ROCM_INSTALL_PATH}/hip;${ROCM_INSTALL_PATH}"
+    -DCMAKE_PREFIX_PATH="${ROCM_INSTALL_PATH}"
 make MIOpen -j $(nproc)
 
 # Build MIOpen package

--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -59,8 +59,11 @@ MIOPEN_CMAKE_COMMON_FLAGS="
 -DMIOPEN_BUILD_DRIVER=OFF
 "
 # Pull MIOpen repo and set DMIOPEN_EMBED_DB based on ROCm version
-if [[ $ROCM_INT -ge 60100 ]] && [[ $ROCM_INT -lt 60200 ]]; then
-    #echo "ROCm 6.1 MIOpen does not need any patches, do not build from source"
+if [[ $ROCM_INT -ge 60300 ]] && [[ $ROCM_INT -lt 60400 ]]; then
+    MIOPEN_BRANCH="release/rocm-rel-6.3"
+elif [[ $ROCM_INT -ge 60200 ]] && [[ $ROCM_INT -lt 60300 ]]; then
+    MIOPEN_BRANCH="release/rocm-rel-6.2"
+elif [[ $ROCM_INT -ge 60100 ]] && [[ $ROCM_INT -lt 60200 ]]; then
     MIOPEN_BRANCH="release/rocm-rel-6.1"
 elif [[ $ROCM_INT -ge 60000 ]] && [[ $ROCM_INT -lt 60100 ]]; then
     echo "ROCm 6.0 MIOpen does not need any patches, do not build from source"

--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -98,6 +98,8 @@ fi
 # Workaround since almalinux manylinux image already has this and cget doesn't like that
 rm -rf /usr/local/lib/pkgconfig/sqlite3.pc
 
+# Versioned package name needs regex match
+# Use --noautoremove to prevent other rocm packages from being uninstalled
 yum remove -y miopen-hip* --noautoremove
 
 git clone https://github.com/ROCm/MIOpen -b ${MIOPEN_BRANCH}

--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -ex
+# Don't use set -e since rocminfo failure 
+# due to /dev/kfd not being visible ends up being fatal
+set -x
 
 ROCM_VERSION=$1
 
@@ -95,7 +97,7 @@ else
     exit 1
 fi
 
-yum remove -y miopen-hip
+yum remove -y miopen-hip* --noautoremove
 
 git clone https://github.com/ROCm/MIOpen -b ${MIOPEN_BRANCH}
 pushd MIOpen

--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -50,6 +50,9 @@ else
     ROCM_INSTALL_PATH="/opt/rocm-${ROCM_VERSION}"
 fi
 
+# Workaround since almalinux manylinux image already has this and cget doesn't like that
+rm -rf /usr/local/lib/pkgconfig/sqlite3.pc
+
 # MIOPEN_USE_HIP_KERNELS is a Workaround for COMgr issues
 MIOPEN_CMAKE_COMMON_FLAGS="
 -DMIOPEN_USE_COMGR=ON
@@ -57,8 +60,8 @@ MIOPEN_CMAKE_COMMON_FLAGS="
 "
 # Pull MIOpen repo and set DMIOPEN_EMBED_DB based on ROCm version
 if [[ $ROCM_INT -ge 60100 ]] && [[ $ROCM_INT -lt 60200 ]]; then
-    echo "ROCm 6.1 MIOpen does not need any patches, do not build from source"
-    exit 0
+    #echo "ROCm 6.1 MIOpen does not need any patches, do not build from source"
+    MIOPEN_BRANCH="release/rocm-rel-6.1"
 elif [[ $ROCM_INT -ge 60000 ]] && [[ $ROCM_INT -lt 60100 ]]; then
     echo "ROCm 6.0 MIOpen does not need any patches, do not build from source"
     exit 0

--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-# Don't use set -e since rocminfo failure 
-# due to /dev/kfd not being visible ends up being fatal
-set -x
+set -ex
 
 ROCM_VERSION=$1
 
@@ -52,9 +50,6 @@ else
     ROCM_INSTALL_PATH="/opt/rocm-${ROCM_VERSION}"
 fi
 
-# Workaround since almalinux manylinux image already has this and cget doesn't like that
-rm -rf /usr/local/lib/pkgconfig/sqlite3.pc
-
 # MIOPEN_USE_HIP_KERNELS is a Workaround for COMgr issues
 MIOPEN_CMAKE_COMMON_FLAGS="
 -DMIOPEN_USE_COMGR=ON
@@ -63,10 +58,16 @@ MIOPEN_CMAKE_COMMON_FLAGS="
 # Pull MIOpen repo and set DMIOPEN_EMBED_DB based on ROCm version
 if [[ $ROCM_INT -ge 60300 ]] && [[ $ROCM_INT -lt 60400 ]]; then
     MIOPEN_BRANCH="release/rocm-rel-6.3"
+    echo "ROCm 6.3 MIOpen does not need any patches, do not build from source"
+    exit 0
 elif [[ $ROCM_INT -ge 60200 ]] && [[ $ROCM_INT -lt 60300 ]]; then
     MIOPEN_BRANCH="release/rocm-rel-6.2"
+    echo "ROCm 6.2 MIOpen does not need any patches, do not build from source"
+    exit 0
 elif [[ $ROCM_INT -ge 60100 ]] && [[ $ROCM_INT -lt 60200 ]]; then
     MIOPEN_BRANCH="release/rocm-rel-6.1"
+    echo "ROCm 6.1 MIOpen does not need any patches, do not build from source"
+    exit 0
 elif [[ $ROCM_INT -ge 60000 ]] && [[ $ROCM_INT -lt 60100 ]]; then
     echo "ROCm 6.0 MIOpen does not need any patches, do not build from source"
     exit 0
@@ -96,6 +97,9 @@ else
     echo "Unhandled ROCM_VERSION ${ROCM_VERSION}"
     exit 1
 fi
+
+# Workaround since almalinux manylinux image already has this and cget doesn't like that
+rm -rf /usr/local/lib/pkgconfig/sqlite3.pc
 
 yum remove -y miopen-hip* --noautoremove
 

--- a/common/install_rocm.sh
+++ b/common/install_rocm.sh
@@ -10,9 +10,6 @@ ver() {
     printf "%3d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
 }
 
-# Map ROCm version to AMDGPU version
-declare -A AMDGPU_VERSIONS=( ["5.0"]="21.50" ["5.1.1"]="22.10.1" ["5.2"]="22.20" )
-
 install_ubuntu() {
     apt-get update
     if [[ $UBUNTU_VERSION == 18.04 ]]; then
@@ -30,26 +27,12 @@ install_ubuntu() {
     apt-get install -y libc++1
     apt-get install -y libc++abi1
 
-    if [[ $(ver $ROCM_VERSION) -ge $(ver 4.5) ]]; then
-        # Add amdgpu repository
-        UBUNTU_VERSION_NAME=`cat /etc/os-release | grep UBUNTU_CODENAME | awk -F= '{print $2}'`
-        local amdgpu_baseurl
-        if [[ $(ver $ROCM_VERSION) -ge $(ver 5.3) ]]; then
-          amdgpu_baseurl="https://repo.radeon.com/amdgpu/${ROCM_VERSION}/ubuntu"
-        else
-          amdgpu_baseurl="https://repo.radeon.com/amdgpu/${AMDGPU_VERSIONS[$ROCM_VERSION]}/ubuntu"
-        fi
-        echo "deb [arch=amd64] ${amdgpu_baseurl} ${UBUNTU_VERSION_NAME} main" > /etc/apt/sources.list.d/amdgpu.list
-    fi
-
-    ROCM_REPO="ubuntu"
-    if [[ $(ver $ROCM_VERSION) -lt $(ver 4.2) ]]; then
-        ROCM_REPO="xenial"
-    fi
-
-    if [[ $(ver $ROCM_VERSION) -ge $(ver 5.3) ]]; then
-        ROCM_REPO="${UBUNTU_VERSION_NAME}"
-    fi
+    # Add amdgpu repository
+    UBUNTU_VERSION_NAME=`cat /etc/os-release | grep UBUNTU_CODENAME | awk -F= '{print $2}'`
+    local amdgpu_baseurl
+    amdgpu_baseurl="https://repo.radeon.com/amdgpu/${ROCM_VERSION}/ubuntu"
+    echo "deb [arch=amd64] ${amdgpu_baseurl} ${UBUNTU_VERSION_NAME} main" > /etc/apt/sources.list.d/amdgpu.list
+    ROCM_REPO="${UBUNTU_VERSION_NAME}"
 
     # Add rocm repository
     wget -qO - http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
@@ -59,11 +42,7 @@ install_ubuntu() {
 
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
                    rocm-dev \
-                   rocm-utils \
-                   rocm-libs \
-                   rccl \
-                   rocprofiler-dev \
-                   roctracer-dev
+                   rocm-libs
 
     # TODO (2)
     ## precompiled miopen kernels added in ROCm 3.5; search for all unversioned packages
@@ -90,26 +69,17 @@ install_centos() {
   yum install -y epel-release
   yum install -y dkms kernel-headers-`uname -r` kernel-devel-`uname -r`
 
-  if [[ $(ver $ROCM_VERSION) -ge $(ver 4.5) ]]; then
-      # Add amdgpu repository
-      local amdgpu_baseurl
-      if [[ $(ver $ROCM_VERSION) -ge $(ver 5.3) ]]; then
-        amdgpu_baseurl="https://repo.radeon.com/amdgpu/${ROCM_VERSION}/rhel/7.9/main/x86_64"
-      else
-        amdgpu_baseurl="https://repo.radeon.com/amdgpu/${AMDGPU_VERSIONS[$ROCM_VERSION]}/rhel/7.9/main/x86_64"
-      fi
-      echo "[AMDGPU]" > /etc/yum.repos.d/amdgpu.repo
-      echo "name=AMDGPU" >> /etc/yum.repos.d/amdgpu.repo
-      echo "baseurl=${amdgpu_baseurl}" >> /etc/yum.repos.d/amdgpu.repo
-      echo "enabled=1" >> /etc/yum.repos.d/amdgpu.repo
-      echo "gpgcheck=1" >> /etc/yum.repos.d/amdgpu.repo
-      echo "gpgkey=http://repo.radeon.com/rocm/rocm.gpg.key" >> /etc/yum.repos.d/amdgpu.repo
-  fi
+  # Add amdgpu repository
+  local amdgpu_baseurl
+  amdgpu_baseurl="https://repo.radeon.com/amdgpu/${ROCM_VERSION}/rhel/7.9/main/x86_64"
+  echo "[AMDGPU]" > /etc/yum.repos.d/amdgpu.repo
+  echo "name=AMDGPU" >> /etc/yum.repos.d/amdgpu.repo
+  echo "baseurl=${amdgpu_baseurl}" >> /etc/yum.repos.d/amdgpu.repo
+  echo "enabled=1" >> /etc/yum.repos.d/amdgpu.repo
+  echo "gpgcheck=1" >> /etc/yum.repos.d/amdgpu.repo
+  echo "gpgkey=http://repo.radeon.com/rocm/rocm.gpg.key" >> /etc/yum.repos.d/amdgpu.repo
 
-  local rocm_baseurl="http://repo.radeon.com/rocm/yum/${ROCM_VERSION}"
-  if [[ $(ver $ROCM_VERSION) -ge $(ver 5.1) ]]; then
-      local rocm_baseurl="http://repo.radeon.com/rocm/yum/${ROCM_VERSION}/main"
-  fi
+  local rocm_baseurl="http://repo.radeon.com/rocm/yum/${ROCM_VERSION}/main"
   echo "[ROCm]" > /etc/yum.repos.d/rocm.repo
   echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo
   echo "baseurl=${rocm_baseurl}" >> /etc/yum.repos.d/rocm.repo
@@ -121,11 +91,7 @@ install_centos() {
 
   yum install -y \
                    rocm-dev \
-                   rocm-utils \
-                   rocm-libs \
-                   rccl \
-                   rocprofiler-dev \
-                   roctracer-dev
+                   rocm-libs
 
   # Cleanup
   yum clean all

--- a/common/install_rocm_drm.sh
+++ b/common/install_rocm_drm.sh
@@ -11,10 +11,7 @@ case "$ID" in
     apt-get install -y libpciaccess-dev pkg-config
     apt-get clean
     ;;
-  centos)
-    yum install -y libpciaccess-devel pkgconfig
-    ;;
-  almalinux)
+  centos|almalinux)
     yum install -y libpciaccess-devel pkgconfig
     ;;
   *)

--- a/common/install_rocm_drm.sh
+++ b/common/install_rocm_drm.sh
@@ -14,6 +14,9 @@ case "$ID" in
   centos)
     yum install -y libpciaccess-devel pkgconfig
     ;;
+  almalinux)
+    yum install -y libpciaccess-devel pkgconfig
+    ;;
   *)
     echo "Unable to determine OS..."
     exit 1

--- a/common/install_rocm_magma.sh
+++ b/common/install_rocm_magma.sh
@@ -6,6 +6,16 @@
 
 set -ex
 
+ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+case "$ID" in
+  almalinux)
+    yum install -y gcc-gfortran
+    ;;
+  *)
+    echo "No preinstalls to build magma..."
+    ;;
+esac
+
 # TODO (2)
 MKLROOT=${MKLROOT:-/opt/intel}
 

--- a/common/install_rocm_magma.sh
+++ b/common/install_rocm_magma.sh
@@ -6,6 +6,9 @@
 
 set -ex
 
+# Magma build scripts need `python`
+ln -sf /usr/bin/python3 /usr/bin/python
+
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
 case "$ID" in
   almalinux)

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -29,9 +29,10 @@ RUN yum install -y devtoolset-${DEVTOOLSET_VERSION}-gcc devtoolset-${DEVTOOLSET_
 ENV PATH=/opt/rh/devtoolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/devtoolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 
-RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    rpm -ivh epel-release-latest-7.noarch.rpm && \
-    rm -f epel-release-latest-7.noarch.rpm
+#Stopped working as of 8/1 (due to CentOS EOL?)
+#RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+#    rpm -ivh epel-release-latest-7.noarch.rpm && \
+#    rm -f epel-release-latest-7.noarch.rpm
 
 # cmake-3.18.4 from pip
 RUN yum install -y python3-pip && \
@@ -116,8 +117,9 @@ RUN yum install -y \
         xz \
         yasm
 RUN yum install -y \
-    https://repo.ius.io/ius-release-el7.rpm \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    https://repo.ius.io/ius-release-el7.rpm
+#Stopped working as of 8/1 (due to CentOS EOL?)
+#    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum swap -y git git236-core
 # git236+ would refuse to run git commands in repos owned by other users
 # Which causes version check to fail, as pytorch repo is bind-mounted into the image

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -83,7 +83,8 @@ RUN yum install -y \
         glibc-langpack-en
 
 RUN yum install -y \
-    https://repo.ius.io/ius-release-el7.rpm
+    https://repo.ius.io/ius-release-el7.rpm \
+    https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm
 #Stopped working as of 8/1 (due to CentOS EOL?)
 #    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum swap -y git git236-core

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -7,7 +7,10 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-RUN yum install -y wget curl perl util-linux xz bzip2 git patch which perl zlib-devel yum-utils
+ARG DEVTOOLSET_VERSION=11
+RUN yum install -y wget curl perl util-linux xz bzip2 git patch which perl zlib-devel yum-utils gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
+ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 
 # cmake-3.18.4 from pip
 RUN yum install -y python3-pip && \
@@ -58,6 +61,7 @@ ADD ./common/install_libpng.sh install_libpng.sh
 RUN bash ./install_libpng.sh && rm install_libpng.sh
 
 FROM ${GPU_IMAGE} as common
+ARG DEVTOOLSET_VERSION=11
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
@@ -80,6 +84,7 @@ RUN yum install -y \
         wget \
         which \
         xz \
+        gcc-toolset-${DEVTOOLSET_VERSION}-toolchain \
         glibc-langpack-en
 
 # ius-release package needs epel-release-7
@@ -113,6 +118,10 @@ COPY --from=jni                /usr/local/include/jni.h              /usr/local/
 
 FROM common as cpu_final
 ARG BASE_CUDA_VERSION=11.8
+ARG DEVTOOLSET_VERSION=11
+# Ensure the expected devtoolset is used
+ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 
 # cmake-3.18.4 from pip; force in case cmake3 already exists
 RUN yum install -y python3-pip && \

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -87,8 +87,6 @@ RUN yum install -y \
         gcc-toolset-${DEVTOOLSET_VERSION}-toolchain \
         glibc-langpack-en
 
-RUN ln -sf /usr/bin/python3 /usr/bin/python
-
 RUN yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -120,10 +120,10 @@ ARG DEVTOOLSET_VERSION=11
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 
-# cmake-3.18.4 from pip
+# cmake-3.18.4 from pip; force in case cmake3 already exists
 RUN yum install -y python3-pip && \
     python3 -mpip install cmake==3.18.4 && \
-    ln -s /usr/local/bin/cmake /usr/bin/cmake3
+    ln -sf /usr/local/bin/cmake /usr/bin/cmake3
 
 FROM cpu_final as cuda_final
 RUN rm -rf /usr/local/cuda-${BASE_CUDA_VERSION}
@@ -139,8 +139,6 @@ ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 ENV ROCM_PATH /opt/rocm
 ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
 RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
-# cmake3 is needed for the MIOpen build
-RUN ln -sf /usr/local/bin/cmake /usr/bin/cmake3
 ADD ./common/install_rocm_magma.sh install_rocm_magma.sh
 RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
 ADD ./common/install_miopen.sh install_miopen.sh

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -83,8 +83,9 @@ RUN yum install -y \
         glibc-langpack-en
 
 RUN yum install -y \
-    https://repo.ius.io/ius-release-el7.rpm \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    https://repo.ius.io/ius-release-el7.rpm
+#Stopped working as of 8/1 (due to CentOS EOL?)
+#    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum swap -y git git236-core
 # git236+ would refuse to run git commands in repos owned by other users
 # Which causes version check to fail, as pytorch repo is bind-mounted into the image

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -87,6 +87,8 @@ RUN yum install -y \
         gcc-toolset-${DEVTOOLSET_VERSION}-toolchain \
         glibc-langpack-en
 
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
 RUN yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -136,6 +136,9 @@ FROM common as rocm_final
 ARG ROCM_VERSION=6.0
 ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
+# Somewhere in ROCm stack, we still use non-existing /opt/rocm/hip path, 
+# below workaround helps avoid error
+ENV ROCM_PATH /opt/rocm
 ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
 RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
 # cmake3 is needed for the MIOpen build

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -137,6 +137,9 @@ ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 # Somewhere in ROCm stack, we still use non-existing /opt/rocm/hip path, 
 # below workaround helps avoid error
 ENV ROCM_PATH /opt/rocm
+# cmake-3.21 from pip to get enable_language(HIP)
+RUN python3 -m pip install --upgrade pip && \
+    python3 -mpip install cmake==3.21
 ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
 RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
 ADD ./common/install_rocm_magma.sh install_rocm_magma.sh

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -128,9 +128,10 @@ ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 # Somewhere in ROCm stack, we still use non-existing /opt/rocm/hip path, 
 # below workaround helps avoid error
 ENV ROCM_PATH /opt/rocm
-# cmake-3.21 from pip to get enable_language(HIP)
+# cmake-3.28.4 from pip to get enable_language(HIP)
+# and avoid 3.21.0 cmake+ninja issues with ninja inserting "-Wl,--no-as-needed" in LINK_FLAGS for static linker
 RUN python3 -m pip install --upgrade pip && \
-    python3 -mpip install cmake==3.21
+    python3 -mpip install cmake==3.28.4
 ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
 RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
 ADD ./common/install_rocm_magma.sh install_rocm_magma.sh

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -82,6 +82,7 @@ RUN yum install -y \
         xz \
         glibc-langpack-en
 
+# ius-release package needs epel-release-7
 RUN yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \
     https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -132,7 +132,7 @@ RUN rm -rf /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=cuda     /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=magma    /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
 
-FROM common as rocm_final
+FROM cpu_final as rocm_final
 ARG ROCM_VERSION=6.0
 ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -141,12 +141,6 @@ RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
 ADD ./common/install_miopen.sh install_miopen.sh
 RUN bash ./install_miopen.sh ${ROCM_VERSION} && rm install_miopen.sh
 
-# Install AOTriton
-COPY ./common/aotriton_version.txt aotriton_version.txt
-COPY ./common/install_aotriton.sh install_aotriton.sh
-RUN bash ./install_aotriton.sh /opt/rocm && rm install_aotriton.sh aotriton_version.txt
-ENV AOTRITON_INSTALLED_PREFIX /opt/rocm/aotriton
-
 FROM cpu_final as xpu_final
 # cmake-3.28.4 from pip
 RUN python3 -m pip install --upgrade pip && \

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -1,5 +1,4 @@
 # syntax = docker/dockerfile:experimental
-ARG ROCM_VERSION=3.7
 ARG BASE_CUDA_VERSION=11.8
 ARG GPU_IMAGE=amd64/almalinux:8
 FROM quay.io/pypa/manylinux_2_28_x86_64 as base
@@ -132,17 +131,23 @@ COPY --from=cuda     /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BAS
 COPY --from=magma    /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
 
 FROM common as rocm_final
-ARG ROCM_VERSION=3.7
-# Install ROCm
-ADD ./common/install_rocm.sh install_rocm.sh
-RUN bash ./install_rocm.sh ${ROCM_VERSION} && rm install_rocm.sh
-# cmake is already installed inside the rocm base image, but both 2 and 3 exist
-# cmake3 is needed for the later MIOpen custom build, so that step is last.
-RUN yum install -y cmake3 && \
-    rm -f /usr/bin/cmake && \
-    ln -s /usr/bin/cmake3 /usr/bin/cmake
+ARG ROCM_VERSION=6.0
+ARG PYTORCH_ROCM_ARCH
+ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
+ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
+RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
+# cmake3 is needed for the MIOpen build
+RUN ln -sf /usr/local/bin/cmake /usr/bin/cmake3
+ADD ./common/install_rocm_magma.sh install_rocm_magma.sh
+RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
 ADD ./common/install_miopen.sh install_miopen.sh
 RUN bash ./install_miopen.sh ${ROCM_VERSION} && rm install_miopen.sh
+
+# Install AOTriton
+COPY ./common/aotriton_version.txt aotriton_version.txt
+COPY ./common/install_aotriton.sh install_aotriton.sh
+RUN bash ./install_aotriton.sh /opt/rocm && rm install_aotriton.sh aotriton_version.txt
+ENV AOTRITON_INSTALLED_PREFIX /opt/rocm/aotriton
 
 FROM cpu_final as xpu_final
 # cmake-3.28.4 from pip

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -152,6 +152,13 @@ else
 fi
 
 if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
+    # Install AOTriton
+    if [ -e .ci/docker/aotriton_version.txt ]; then
+        cp -a .ci/docker/aotriton_version.txt aotriton_version.txt
+        bash ${SOURCE_DIR}/../common/install_aotriton.sh /opt/rocm && rm aotriton_version.txt
+        export AOTRITON_INSTALLED_PREFIX=/opt/rocm/aotriton
+    fi
+
     echo "Calling build_amd.py at $(date)"
     python tools/amd_build/build_amd.py
 fi

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -152,13 +152,6 @@ else
 fi
 
 if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
-    # Install AOTriton
-    if [ -e .ci/docker/aotriton_version.txt ]; then
-        cp -a .ci/docker/aotriton_version.txt aotriton_version.txt
-        bash ${SOURCE_DIR}/../common/install_aotriton.sh /opt/rocm && rm aotriton_version.txt
-        export AOTRITON_INSTALLED_PREFIX=/opt/rocm/aotriton
-    fi
-
     echo "Calling build_amd.py at $(date)"
     python tools/amd_build/build_amd.py
 fi

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -145,6 +145,7 @@ case ${DESIRED_PYTHON} in
     ;;
 esac
 
+# ROCm RHEL8 packages are built with cxx11 abi symbols
 if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* || "$DESIRED_CUDA" == *"rocm"* ]]; then
     export _GLIBCXX_USE_CXX11_ABI=1
 else

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -120,16 +120,28 @@ fi
 pushd "$PYTORCH_ROOT"
 python setup.py clean
 retry pip install -qr requirements.txt
+ver() {
+    printf "%3d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
+}
 case ${DESIRED_PYTHON} in
   cp38*)
     retry pip install -q numpy==1.15
     ;;
   cp31*)
-    retry pip install -q --pre numpy==2.0.0rc1
+    # CIRCLE_TAG contains the PyTorch version such as "1.13.0"
+    if [[ $(ver ${CIRCLE_TAG}) -ge $(ver 2.4) ]]; then
+      retry pip install -q --pre numpy==2.0.0rc1
+    else
+      retry pip install -q "numpy<2.0.0"
+    fi
     ;;
   # Should catch 3.9+
   *)
-    retry pip install -q --pre numpy==2.0.0rc1
+    if [[ $(ver ${CIRCLE_TAG}) -ge $(ver 2.4) ]]; then
+      retry pip install -q --pre numpy==2.0.0rc1
+    else
+      retry pip install -q "numpy<2.0.0"
+    fi
     ;;
 esac
 

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -133,7 +133,7 @@ case ${DESIRED_PYTHON} in
     ;;
 esac
 
-if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
+if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* || "$DESIRED_CUDA" == *"rocm"* ]]; then
     export _GLIBCXX_USE_CXX11_ABI=1
 else
     export _GLIBCXX_USE_CXX11_ABI=0

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -93,7 +93,7 @@ case ${GPU_ARCH_TYPE} in
 	    GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
 	fi
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=9"
-	;;
+        ;;
     xpu)
         TARGET=xpu_final
         DOCKER_TAG=xpu

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -91,10 +91,12 @@ case ${GPU_ARCH_TYPE} in
         if [[ $ROCM_VERSION_INT -ge 60000 ]]; then
             PYTORCH_ROCM_ARCH+=";gfx942"
         fi
-        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=9"
+	DEVTOOLSET_VERSION=9
         if [ ${GPU_ARCH_TYPE} == "rocm-manylinux_2_28" ]; then
             MANY_LINUX_VERSION="2_28"
+	    DEVTOOLSET_VERSION=11
 	fi
+        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
 	;;
     xpu)
         TARGET=xpu_final

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -90,6 +90,7 @@ case ${GPU_ARCH_TYPE} in
         fi
         if [ ${GPU_ARCH_TYPE} == "rocm-manylinux_2_28" ]; then
             MANY_LINUX_VERSION="2_28"
+	    GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
 	fi
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=9"
 	;;

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -80,7 +80,7 @@ case ${GPU_ARCH_TYPE} in
         TARGET=rocm_final
         DOCKER_TAG=rocm${GPU_ARCH_VERSION}
         GPU_IMAGE=rocm/dev-centos-7:${GPU_ARCH_VERSION}-complete
-        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100"
+        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100"
         ROCM_REGEX="([0-9]+)\.([0-9]+)[\.]?([0-9]*)"
         if [[ $GPU_ARCH_VERSION =~ $ROCM_REGEX ]]; then
             ROCM_VERSION_INT=$((${BASH_REMATCH[1]}*10000 + ${BASH_REMATCH[2]}*100 + ${BASH_REMATCH[3]:-0}))
@@ -88,14 +88,10 @@ case ${GPU_ARCH_TYPE} in
             echo "ERROR: rocm regex failed"
             exit 1
         fi
-        if [[ $ROCM_VERSION_INT -ge 60000 ]]; then
-            PYTORCH_ROCM_ARCH+=";gfx942"
-        fi
-	DEVTOOLSET_VERSION=9
         if [ ${GPU_ARCH_TYPE} == "rocm-manylinux_2_28" ]; then
             MANY_LINUX_VERSION="2_28"
 	fi
-        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
+        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=9"
 	;;
     xpu)
         TARGET=xpu_final

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -76,7 +76,7 @@ case ${GPU_ARCH_TYPE} in
         MANY_LINUX_VERSION="aarch64"
         DOCKERFILE_SUFFIX="_cuda_aarch64"
         ;;
-    rocm)
+    rocm|rocm-manylinux_2_28)
         TARGET=rocm_final
         DOCKER_TAG=rocm${GPU_ARCH_VERSION}
         GPU_IMAGE=rocm/dev-centos-7:${GPU_ARCH_VERSION}-complete
@@ -92,25 +92,9 @@ case ${GPU_ARCH_TYPE} in
             PYTORCH_ROCM_ARCH+=";gfx942"
         fi
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=9"
-        ;;
-    rocm-manylinux_2_28)
-        TARGET=rocm_final
-        DOCKER_TAG=rocm${GPU_ARCH_VERSION}
-        GPU_IMAGE=amd64/almalinux:8
-        #PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100"
-        PYTORCH_ROCM_ARCH="gfx908;gfx90a"
-        ROCM_REGEX="([0-9]+)\.([0-9]+)[\.]?([0-9]*)"
-        if [[ $GPU_ARCH_VERSION =~ $ROCM_REGEX ]]; then
-            ROCM_VERSION_INT=$((${BASH_REMATCH[1]}*10000 + ${BASH_REMATCH[2]}*100 + ${BASH_REMATCH[3]:-0}))
-        else
-            echo "ERROR: rocm regex failed"
-            exit 1
-        fi
-        #if [[ $ROCM_VERSION_INT -ge 60000 ]]; then
-        #    PYTORCH_ROCM_ARCH+=";gfx942"
-        #fi
-        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=11"
-        MANY_LINUX_VERSION="2_28"
+        if [ ${GPU_ARCH_TYPE} == "rocm-manylinux_2_28" ]; then
+            MANY_LINUX_VERSION="2_28"
+	fi
 	;;
     xpu)
         TARGET=xpu_final

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -94,7 +94,6 @@ case ${GPU_ARCH_TYPE} in
 	DEVTOOLSET_VERSION=9
         if [ ${GPU_ARCH_TYPE} == "rocm-manylinux_2_28" ]; then
             MANY_LINUX_VERSION="2_28"
-	    DEVTOOLSET_VERSION=11
 	fi
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
 	;;

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -109,7 +109,7 @@ case ${GPU_ARCH_TYPE} in
         #if [[ $ROCM_VERSION_INT -ge 60000 ]]; then
         #    PYTORCH_ROCM_ARCH+=";gfx942"
         #fi
-        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=9"
+        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=11"
         MANY_LINUX_VERSION="2_28"
 	;;
     xpu)

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -93,6 +93,25 @@ case ${GPU_ARCH_TYPE} in
         fi
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=9"
         ;;
+    rocm-manylinux_2_28)
+        TARGET=rocm_final
+        DOCKER_TAG=rocm${GPU_ARCH_VERSION}
+        GPU_IMAGE=amd64/almalinux:8
+        #PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100"
+        PYTORCH_ROCM_ARCH="gfx908;gfx90a"
+        ROCM_REGEX="([0-9]+)\.([0-9]+)[\.]?([0-9]*)"
+        if [[ $GPU_ARCH_VERSION =~ $ROCM_REGEX ]]; then
+            ROCM_VERSION_INT=$((${BASH_REMATCH[1]}*10000 + ${BASH_REMATCH[2]}*100 + ${BASH_REMATCH[3]:-0}))
+        else
+            echo "ERROR: rocm regex failed"
+            exit 1
+        fi
+        #if [[ $ROCM_VERSION_INT -ge 60000 ]]; then
+        #    PYTORCH_ROCM_ARCH+=";gfx942"
+        #fi
+        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=9"
+        MANY_LINUX_VERSION="2_28"
+	;;
     xpu)
         TARGET=xpu_final
         DOCKER_TAG=xpu

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -201,8 +201,13 @@ do
 done
 
 # PyTorch-version specific
-# AOTriton dependency only for PyTorch >= 2.4
-if (( $(echo "${PYTORCH_VERSION} 2.4" | awk '{print ($1 >= $2)}') )); then
+# AOTriton dependency only for PyTorch >= 2.3
+# Install AOTriton
+if [ -e ${PYTORCH_ROOT}/.ci/docker/aotriton_version.txt ]; then
+    cp -a ${PYTORCH_ROOT}/.ci/docker/aotriton_version.txt aotriton_version.txt
+    SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+    bash ${SOURCE_DIR}/../common/install_aotriton.sh ${ROCM_HOME} && rm aotriton_version.txt
+    export AOTRITON_INSTALLED_PREFIX=${ROCM_HOME}/aotriton
     ROCM_SO_FILES+=("libaotriton_v2.so")
 fi
 

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -115,6 +115,10 @@ if [[ $ROCM_INT -ge 60100 ]]; then
     ROCM_SO_FILES+=("librocprofiler-register.so")
 fi
 
+if [[ $ROCM_INT -ge 60200 ]]; then
+    ROCM_SO_FILES+=("librocm-core.so")
+fi
+
 OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
 if [[ "$OS_NAME" == *"CentOS Linux"* || "$OS_NAME" == *"AlmaLinux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -116,7 +116,7 @@ if [[ $ROCM_INT -ge 60100 ]]; then
 fi
 
 OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
-if [[ "$OS_NAME" == *"CentOS Linux"* || "$OS_NAME" == "AlmaLinux" ]]; then
+if [[ "$OS_NAME" == *"CentOS Linux"* || "$OS_NAME" == *"AlmaLinux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
     LIBNUMA_PATH="/usr/lib64/libnuma.so.1"
     LIBELF_PATH="/usr/lib64/libelf.so.1"

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -116,17 +116,29 @@ if [[ $ROCM_INT -ge 60100 ]]; then
 fi
 
 OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
-if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+if [[ "$OS_NAME" == *"CentOS Linux"* || "$OS_NAME" == "AlmaLinux" ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
     LIBNUMA_PATH="/usr/lib64/libnuma.so.1"
     LIBELF_PATH="/usr/lib64/libelf.so.1"
-    LIBTINFO_PATH="/usr/lib64/libtinfo.so.5"
+    if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+        LIBTINFO_PATH="/usr/lib64/libtinfo.so.5"
+    else
+        LIBTINFO_PATH="/usr/lib64/libtinfo.so.6"
+    fi
     LIBDRM_PATH="/opt/amdgpu/lib64/libdrm.so.2"
     LIBDRM_AMDGPU_PATH="/opt/amdgpu/lib64/libdrm_amdgpu.so.1"
     if [[ $ROCM_INT -ge 60100 ]]; then
         # Below libs are direct dependencies of libhipsolver
         LIBSUITESPARSE_CONFIG_PATH="/lib64/libsuitesparseconfig.so.4"
+    if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
         LIBCHOLMOD_PATH="/lib64/libcholmod.so.2"
+        # Below libs are direct dependencies of libsatlas
+        LIBGFORTRAN_PATH="/lib64/libgfortran.so.3"
+    else
+        LIBCHOLMOD_PATH="/lib64/libcholmod.so.3"
+        # Below libs are direct dependencies of libsatlas
+        LIBGFORTRAN_PATH="/lib64/libgfortran.so.5"
+    fi
         # Below libs are direct dependencies of libcholmod
         LIBAMD_PATH="/lib64/libamd.so.2"
         LIBCAMD_PATH="/lib64/libcamd.so.2"
@@ -134,7 +146,6 @@ if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
         LIBCOLAMD_PATH="/lib64/libcolamd.so.2"
         LIBSATLAS_PATH="/lib64/atlas/libsatlas.so.3"
         # Below libs are direct dependencies of libsatlas
-        LIBGFORTRAN_PATH="/lib64/libgfortran.so.3"
         LIBQUADMATH_PATH="/lib64/libquadmath.so.0"
     fi
     MAYBE_LIB64=lib64


### PR DESCRIPTION
* Add manylinux2_28 case to `manywheel/build_docker.sh`
* Update steps to install libraries such as magma for ROCm
* Clean up old-ROCm-version code
* Use _GLIBCXX_USE_CXX11_ABI=1: https://github.com/ROCm/builder/pull/51/commits/9daa4e4b540b7c39c82b8d60b45d93b866dd7241
* Install numpy<2.0.0 for PyTorch versions<2.4: https://github.com/ROCm/builder/pull/51/commits/6bf4bfd163f3810f6e2d016145fde94dca688527
* Add conditions for ROCm6.2 and ROCm6.3 in `common/install_miopen.sh`
* Upgrade CMake version to 3.28.4 (need minimum of 3.21 to get `enable_langugage(HIP)` support, but 3.21 has a bug that inserts dynamic linker flags `-Wl,no-as-needed` in static linker flags causing build failure)
* Skip unnecessary installation of epel rpm from expired link for CentOS7
* Install epel-release-7 from cached rpm to enable ius-release to be installed for Almalinux8

TODO:
- [x] Cherry-pick changes to rocm6.2 branch - Not needed since ROCm6.2.x stays on CentOS7-based flow

Tested via: http://ml-ci-internal.amd.com:8080/job/pytorch/job/dev/job/manylinux_rocm_wheels_test/158/
