### PR TITLE
[rocm6.2] Wheel build remove quiet pip

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -117,7 +117,7 @@ if [[ -z "$PYTORCH_ROOT" ]]; then
 fi
 pushd "$PYTORCH_ROOT"
 python setup.py clean
-retry pip install -qr requirements.txt
+retry pip install -r requirements.txt
 case ${DESIRED_PYTHON} in
   cp36-cp36m)
     retry pip install -q numpy==1.11

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -189,7 +189,7 @@ if [[ "$(uname -m)" == "arm64" ]]; then
 else
   retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake ninja mkl-include==2022.2.1 mkl-static==2022.2.1 -c intel
 fi
-retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
+retry pip install -r "${pytorch_rootdir}/requirements.txt" || true
 
 # For USE_DISTRIBUTED=1 on macOS, need libuv and pkg-config to find libuv.
 export USE_DISTRIBUTED=1


### PR DESCRIPTION
Removed pip install -quiet for better build debug info.