### PR TITLE
Set _GLIBCXX_USE_CXX11_ABI=0 for ROCm

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -145,8 +145,8 @@ case ${DESIRED_PYTHON} in
     ;;
 esac
 
-# ROCm RHEL8 packages are built with cxx11 abi symbols
-if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* || "$DESIRED_CUDA" == *"rocm"* ]]; then
+# WARNING: ROCm RHEL8 packages are built with cxx11 abi symbols
+if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
     export _GLIBCXX_USE_CXX11_ABI=1
 else
     export _GLIBCXX_USE_CXX11_ABI=0


### PR DESCRIPTION
This reverts a change introduced when enabling manylinux2_28 wheels because PyTorch was running into build errors when building with `_GLIBCXX_USE_CXX11_ABI=0`. However, https://github.com/ROCm/pytorch/pull/1640 should have fixed that, so we can reenable building PyTorch with `_GLIBCXX_USE_CXX11_ABI=0`.