### PR TITLE
Enable py3.13 wheels 

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -11,6 +11,10 @@ ARG DEVTOOLSET_VERSION=11
 RUN yum install -y wget curl perl util-linux xz bzip2 git patch which perl zlib-devel yum-utils gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
+# Install setuptools and wheel for python 3.12/3.13
+RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
+    /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
+    done;
 
 # cmake-3.18.4 from pip
 RUN yum install -y python3-pip && \


### PR DESCRIPTION
Add in setuptools and wheel package in the dockerfile because they are not included in 3.12 onwards
Related to https://github.com/ROCm/rocAutomation/pull/593
Validation:
http://ml-ci-internal.amd.com:8080/job/pytorch/job/dev/job/lightweight_wheels_test/297/