### PR TITLE
Append torch commit to wheel name

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -73,14 +73,19 @@ if [[ "$BUILD_LIGHTWEIGHT" == "1" ]]; then
     build_version="${build_version}.lw"
 fi
 
-# New code to append the commit to the build_version
-# This assumes $PYTORCH_COMMIT is set to a full git SHA
-if [[ -n "$PYTORCH_COMMIT" ]]; then
-    # Append the commit as a ".git<shortsha>" suffix
-    # This yields versions like: torch-2.5.0+rocm6.2.0.lw.gitabcd1234
-    short_commit=$(echo "$PYTORCH_COMMIT" | cut -c1-8)
-    build_version="${build_version}.git${short_commit}"
+if [[ -z "$PYTORCH_ROOT" ]]; then
+    echo "Need to set PYTORCH_ROOT env variable"
+    exit 1
 fi
+# Always append the pytorch commit to the build_version by querying Git
+pushd "$PYTORCH_ROOT"
+PYTORCH_COMMIT=$(git rev-parse HEAD)
+popd
+
+# Append the commit as a ".git<shortsha>" suffix
+# This yields versions like: torch-2.5.0+rocm6.2.0.lw.gitabcd1234
+short_commit=$(echo "$PYTORCH_COMMIT" | cut -c1-8)
+build_version="${build_version}.git${short_commit}"
 
 echo "Final build_version: $build_version"
 
@@ -128,10 +133,7 @@ fi
 ########################################################
 # Compile wheels as well as libtorch
 #######################################################
-if [[ -z "$PYTORCH_ROOT" ]]; then
-    echo "Need to set PYTORCH_ROOT env variable"
-    exit 1
-fi
+
 pushd "$PYTORCH_ROOT"
 python setup.py clean
 retry pip install -r requirements.txt

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -77,9 +77,9 @@ fi
 # This assumes $PYTORCH_COMMIT is set to a full git SHA
 if [[ -n "$PYTORCH_COMMIT" ]]; then
     # Append the commit as a "+git<shortsha>" suffix
-    # This yields versions like: 1.13.0.lw+gitabc1234
-    short_commit=$(echo "$PYTORCH_COMMIT" | cut -c1-7)
-    build_version="${build_version}+${short_commit}"
+    # This yields versions like: torch-2.5.0+rocm6.2.0.lw.gitabcd1234
+    short_commit=$(echo "$PYTORCH_COMMIT" | cut -c1-8)
+    build_version="${build_version}.git${short_commit}"
 fi
 
 echo "Final build_version: $build_version"

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -73,6 +73,15 @@ if [[ "$BUILD_LIGHTWEIGHT" == "1" ]]; then
     build_version="${build_version}.lw"
 fi
 
+# New code to append the commit to the build_version
+# This assumes $PYTORCH_COMMIT is set to a full git SHA
+if [[ -n "$PYTORCH_COMMIT" ]]; then
+    # Append the commit as a "+git<shortsha>" suffix
+    # This yields versions like: 1.13.0.lw+gitabc1234
+    short_commit=$(echo "$PYTORCH_COMMIT" | cut -c1-7)
+    build_version="${build_version}+git${short_commit}"
+fi
+
 echo "Final build_version: $build_version"
 
 export PYTORCH_BUILD_VERSION=$build_version

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -79,7 +79,7 @@ if [[ -n "$PYTORCH_COMMIT" ]]; then
     # Append the commit as a "+git<shortsha>" suffix
     # This yields versions like: 1.13.0.lw+gitabc1234
     short_commit=$(echo "$PYTORCH_COMMIT" | cut -c1-7)
-    build_version="${build_version}+git${short_commit}"
+    build_version="${build_version}+${short_commit}"
 fi
 
 echo "Final build_version: $build_version"

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -76,7 +76,7 @@ fi
 # New code to append the commit to the build_version
 # This assumes $PYTORCH_COMMIT is set to a full git SHA
 if [[ -n "$PYTORCH_COMMIT" ]]; then
-    # Append the commit as a "+git<shortsha>" suffix
+    # Append the commit as a ".git<shortsha>" suffix
     # This yields versions like: torch-2.5.0+rocm6.2.0.lw.gitabcd1234
     short_commit=$(echo "$PYTORCH_COMMIT" | cut -c1-8)
     build_version="${build_version}.git${short_commit}"


### PR DESCRIPTION
Adds in torch commit for which pytorch is built on. Relates to [ rocAutomation/pull/638](https://github.com/ROCm/rocAutomation/pull/638)

Validation:
http://ml-ci-internal.amd.com:8080/job/pytorch/job/dev/job/lightweight_wheels_test/348/