### PR TITLE
Additional changes to make heavyweight + lightweight wheel generation work

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -196,7 +196,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     rm -f $pkg
     mv $(basename $pkg) $pkg
     // Rename wheel to match metadata in dist-info
-    mv $pkg "$(echo $pkg | sed \"s/\.git/${WHEELNAME_MARKER}.git/\")"
+    mv $pkg "$(echo $pkg | sed -e "s/\.git/${WHEELNAME_MARKER}.git/")"
     cd ..
     rm -rf tmp
 done

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -195,7 +195,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     # replace original wheel
     rm -f $pkg
     mv $(basename $pkg) $pkg
-    // Rename wheel to match metadata in dist-info
+    # Rename wheel to match metadata in dist-info
     mv $pkg $(echo $pkg | sed -e "s/\.git/${WHEELNAME_MARKER}.git/")
     cd ..
     rm -rf tmp

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -82,11 +82,13 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     unzip -q $(basename $pkg)
     rm -f $(basename $pkg)
 
-    dist_info_dir="$(ls -d *dist-info)"
-    # Replace "Version: " entry in METADATA file with WHEELNAME_MARKER
-    sed -i -e "/Version: /s/.git/${WHEELNAME_MARKER}.git/" ${dist_info_dir}/METADATA
-    # Rename dist-info directory to contain WHEELNAME_MARKER
-    mv ${dist_info_dir} $(echo "${dist_info_dir}" | sed -e "s/.git/${WHEELNAME_MARKER}.git/")
+    if [[ -n "${WHEELNAME_MARKER}" ]]; then
+        dist_info_dir="$(ls -d *dist-info)"
+        # Replace "Version: " entry in METADATA file with WHEELNAME_MARKER
+        sed -i -e "/Version: /s/.git/${WHEELNAME_MARKER}.git/" ${dist_info_dir}/METADATA
+        # Rename dist-info directory to contain WHEELNAME_MARKER
+        mv ${dist_info_dir} $(echo "${dist_info_dir}" | sed -e "s/.git/${WHEELNAME_MARKER}.git/")
+    fi
 
     if [[ -d torch ]]; then
         PREFIX=torch
@@ -195,8 +197,10 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     # replace original wheel
     rm -f $pkg
     mv $(basename $pkg) $pkg
-    # Rename wheel to match metadata in dist-info
-    mv $pkg $(echo $pkg | sed -e "s/\.git/${WHEELNAME_MARKER}.git/")
+    if [[ -n "${WHEELNAME_MARKER}" ]]; then
+        # Rename wheel to match metadata in dist-info
+        mv $pkg $(echo $pkg | sed -e "s/\.git/${WHEELNAME_MARKER}.git/")
+    fi
     cd ..
     rm -rf tmp
 done

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -204,6 +204,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     # replace original wheel
     rm -f $pkg
     mv $(basename $pkg) $pkg
+    # Rename wheel to reflect lightweight/heavyweight
     if [[ -n "${WHEELNAME_MARKER}" ]]; then
         # Rename wheel to match metadata in dist-info
         mv $pkg $(echo $pkg | sed -e "s/\.git/${WHEELNAME_MARKER}.git/")

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -82,6 +82,12 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*${WHEELN
     unzip -q $(basename $pkg)
     rm -f $(basename $pkg)
 
+    dist_info_dir="$(ls -d *dist-info)"
+    # Replace "Version: " entry in METADATA file with WHEELNAME_MARKER
+    sed -i -e "/Version: /s/.git/.${WHEELNAME_MARKER}.git/" ${dist_info_dir}/METADATA
+    # Rename dist-info directory to contain WHEELNAME_MARKER
+    mv ${dist_info_dir} $(echo "${dist_info_dir}" | sed -e "s/.git/.${WHEELNAME_MARKER}.git/g")
+
     if [[ -d torch ]]; then
         PREFIX=torch
     else

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -86,7 +86,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     # Replace "Version: " entry in METADATA file with WHEELNAME_MARKER
     sed -i -e "/Version: /s/.git/${WHEELNAME_MARKER}.git/" ${dist_info_dir}/METADATA
     # Rename dist-info directory to contain WHEELNAME_MARKER
-    mv ${dist_info_dir} $(echo "${dist_info_dir}" | sed -e "s/.git/${WHEELNAME_MARKER}.git/g")
+    mv ${dist_info_dir} $(echo "${dist_info_dir}" | sed -e "s/.git/${WHEELNAME_MARKER}.git/")
 
     if [[ -d torch ]]; then
         PREFIX=torch
@@ -196,7 +196,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     rm -f $pkg
     mv $(basename $pkg) $pkg
     // Rename wheel to match metadata in dist-info
-    mv $pkg "$(echo $pkg | sed -e "s/\.git/${WHEELNAME_MARKER}.git/")"
+    mv $pkg $(echo $pkg | sed -e "s/\.git/${WHEELNAME_MARKER}.git/")
     cd ..
     rm -rf tmp
 done

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -68,7 +68,7 @@ replace_needed_sofiles() {
 rm -rf /tmp_dir
 mkdir /tmp_dir
 pushd /tmp_dir
-for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip; do
+for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*${WHEELNAME_MARKER}*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip; do
 
     # if the glob didn't match anything
     if [[ ! -e $pkg ]]; then
@@ -199,13 +199,7 @@ if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
     if [[ -n "$BUILD_PYTHONLESS" ]]; then
         cp /$LIBTORCH_HOUSE_DIR/libtorch*.zip "$PYTORCH_FINAL_PACKAGE_DIR"
     else
-        if [ "${BUILD_LIGHTWEIGHT}" == "0" ]; then
-          # Remove .lw. from the final copy
-          cp "/${WHEELHOUSE_DIR}"/torch*.whl "${PYTORCH_FINAL_PACKAGE_DIR}/$(basename "/${WHEELHOUSE_DIR}"/torch*.whl | sed 's/\.lw//')"
-        else
-          # Copy as-is
-          cp "/${WHEELHOUSE_DIR}"/torch*.whl "${PYTORCH_FINAL_PACKAGE_DIR}"
-        fi
+        cp "/${WHEELHOUSE_DIR}"/torch*${WHEELNAME_MARKER}*.whl "${PYTORCH_FINAL_PACKAGE_DIR}"
     fi
 fi
 

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -155,9 +155,10 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
 
     # regenerate the RECORD file with new hashes
     # record_file=$(echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/RECORD/g')
-    record_file=$(ls ${dist_info_dir}/RECORD)
     if [[ -n "${WHEELNAME_MARKER}" ]]; then
         record_file=$(ls ${new_dist_info_dir}/RECORD)
+    else
+        record_file=$(ls ${dist_info_dir}/RECORD)
     fi
 
     if [[ -e $record_file ]]; then

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -82,12 +82,13 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     unzip -q $(basename $pkg)
     rm -f $(basename $pkg)
 
+    dist_info_dir="$(ls -d *dist-info)"
     if [[ -n "${WHEELNAME_MARKER}" ]]; then
-        dist_info_dir="$(ls -d *dist-info)"
         # Replace "Version: " entry in METADATA file with WHEELNAME_MARKER
         sed -i -e "/Version: /s/.git/${WHEELNAME_MARKER}.git/" ${dist_info_dir}/METADATA
         # Rename dist-info directory to contain WHEELNAME_MARKER
-        mv ${dist_info_dir} $(echo "${dist_info_dir}" | sed -e "s/.git/${WHEELNAME_MARKER}.git/")
+        new_dist_info_dir=$(echo "${dist_info_dir}" | sed -e "s/.git/${WHEELNAME_MARKER}.git/")
+        mv ${dist_info_dir} ${new_dist_info_dir} 
     fi
 
     if [[ -d torch ]]; then
@@ -153,7 +154,12 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MA
     done
 
     # regenerate the RECORD file with new hashes
-    record_file=$(echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/RECORD/g')
+    # record_file=$(echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/RECORD/g')
+    record_file=$(ls ${dist_info_dir}/RECORD)
+    if [[ -n "${WHEELNAME_MARKER}" ]]; then
+        record_file=$(ls ${new_dist_info_dir}/RECORD)
+    fi
+
     if [[ -e $record_file ]]; then
         echo "Generating new record file $record_file"
         : > "$record_file"

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -68,7 +68,7 @@ replace_needed_sofiles() {
 rm -rf /tmp_dir
 mkdir /tmp_dir
 pushd /tmp_dir
-for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*${WHEELNAME_MARKER}*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip; do
+for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MARKER}/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip; do
 
     # if the glob didn't match anything
     if [[ ! -e $pkg ]]; then
@@ -84,9 +84,9 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*${WHEELN
 
     dist_info_dir="$(ls -d *dist-info)"
     # Replace "Version: " entry in METADATA file with WHEELNAME_MARKER
-    sed -i -e "/Version: /s/.git/.${WHEELNAME_MARKER}.git/" ${dist_info_dir}/METADATA
+    sed -i -e "/Version: /s/.git/${WHEELNAME_MARKER}.git/" ${dist_info_dir}/METADATA
     # Rename dist-info directory to contain WHEELNAME_MARKER
-    mv ${dist_info_dir} $(echo "${dist_info_dir}" | sed -e "s/.git/.${WHEELNAME_MARKER}.git/g")
+    mv ${dist_info_dir} $(echo "${dist_info_dir}" | sed -e "s/.git/${WHEELNAME_MARKER}.git/g")
 
     if [[ -d torch ]]; then
         PREFIX=torch
@@ -195,6 +195,8 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*${WHEELN
     # replace original wheel
     rm -f $pkg
     mv $(basename $pkg) $pkg
+    // Rename wheel to match metadata in dist-info
+    mv $pkg "$(echo $pkg | sed \"s/\.git/${WHEELNAME_MARKER}.git/\")"
     cd ..
     rm -rf tmp
 done
@@ -205,7 +207,7 @@ if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
     if [[ -n "$BUILD_PYTHONLESS" ]]; then
         cp /$LIBTORCH_HOUSE_DIR/libtorch*.zip "$PYTORCH_FINAL_PACKAGE_DIR"
     else
-        cp "/${WHEELHOUSE_DIR}"/torch*${WHEELNAME_MARKER}*.whl "${PYTORCH_FINAL_PACKAGE_DIR}"
+        cp "/${WHEELHOUSE_DIR}/${WHEELNAME_MARKER}"/torch*.whl "${PYTORCH_FINAL_PACKAGE_DIR}"
     fi
 fi
 
@@ -229,10 +231,10 @@ if [[ -z "$BUILD_PYTHONLESS" ]]; then
   pip uninstall -y "$TORCH_PACKAGE_NAME"
   
   if [[ "$USE_SPLIT_BUILD" == "true" ]]; then
-    pip install "$TORCH_NO_PYTHON_PACKAGE_NAME" --no-index -f /$WHEELHOUSE_DIR --no-dependencies -v
+    pip install "$TORCH_NO_PYTHON_PACKAGE_NAME" --no-index -f /$WHEELHOUSE_DIR/${WHEELNAME_MARKER} --no-dependencies -v
   fi
   
-  pip install "$TORCH_PACKAGE_NAME" --no-index -f /$WHEELHOUSE_DIR --no-dependencies -v
+  pip install "$TORCH_PACKAGE_NAME" --no-index -f /$WHEELHOUSE_DIR/${WHEELNAME_MARKER} --no-dependencies -v
 
   # Print info on the libraries installed in this wheel
   # Rather than adjust find command to skip non-library files with an embedded *.so* in their name,

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -74,152 +74,14 @@ fi
 ROCM_VERSION_WITH_PATCH=rocm${ROCM_VERSION_MAJOR}.${ROCM_VERSION_MINOR}.${ROCM_VERSION_PATCH}
 ROCM_INT=$(($ROCM_VERSION_MAJOR * 10000 + $ROCM_VERSION_MINOR * 100 + $ROCM_VERSION_PATCH))
 
-# Required ROCm libraries
-LIGHTWEIGHT_ROCM_SO_FILES=(
-    # Minimal set for lightweight
-    "libmagma.so"
-)
-
-HEAVYWEIGHT_ROCM_SO_FILES=(
-    # Full set for heavyweight
-    "libMIOpen.so"
-    "libamdhip64.so"
-    "libhipblas.so"
-    "libhipblaslt.so"
-    "libhipfft.so"
-    "libhiprand.so"
-    "libhipsolver.so"
-    "libhipsparse.so"
-    "libhsa-runtime64.so"
-    "libhiprtc.so"
-    "libamd_comgr.so"
-    "libmagma.so"
-    "librccl.so"
-    "librocblas.so"
-    "librocfft.so"
-    "librocm_smi64.so"
-    "librocrand.so"
-    "librocsolver.so"
-    "librocsparse.so"
-    "libroctracer64.so"
-    "libroctx64.so"
-)
-
-# Adjust list based on ROCm version
-if [[ $ROCM_INT -ge 60100 ]]; then
-    HEAVYWEIGHT_ROCM_SO_FILES+=("librocprofiler-register.so")
-fi
-if [[ $ROCM_INT -ge 60200 ]]; then
-    HEAVYWEIGHT_ROCM_SO_FILES+=("librocm-core.so")
-fi
-
-
-
-OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
-if [[ "$OS_NAME" == *"CentOS Linux"* || "$OS_NAME" == *"AlmaLinux"* ]]; then
-    LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
-    LIBNUMA_PATH="/usr/lib64/libnuma.so.1"
-    LIBELF_PATH="/usr/lib64/libelf.so.1"
-    if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
-        LIBTINFO_PATH="/usr/lib64/libtinfo.so.5"
-    else
-        LIBTINFO_PATH="/usr/lib64/libtinfo.so.6"
-    fi
-    LIBDRM_PATH="/opt/amdgpu/lib64/libdrm.so.2"
-    LIBDRM_AMDGPU_PATH="/opt/amdgpu/lib64/libdrm_amdgpu.so.1"
-    if [[ $ROCM_INT -ge 60100 && $ROCM_INT -lt 60300 ]]; then
-        # Below libs are direct dependencies of libhipsolver
-        LIBSUITESPARSE_CONFIG_PATH="/lib64/libsuitesparseconfig.so.4"
-        if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
-            LIBCHOLMOD_PATH="/lib64/libcholmod.so.2"
-            # Below libs are direct dependencies of libsatlas
-            LIBGFORTRAN_PATH="/lib64/libgfortran.so.3"
-        else
-            LIBCHOLMOD_PATH="/lib64/libcholmod.so.3"
-            # Below libs are direct dependencies of libsatlas
-            LIBGFORTRAN_PATH="/lib64/libgfortran.so.5"
-        fi
-            # Below libs are direct dependencies of libcholmod
-            LIBAMD_PATH="/lib64/libamd.so.2"
-            LIBCAMD_PATH="/lib64/libcamd.so.2"
-            LIBCCOLAMD_PATH="/lib64/libccolamd.so.2"
-            LIBCOLAMD_PATH="/lib64/libcolamd.so.2"
-            LIBSATLAS_PATH="/lib64/atlas/libsatlas.so.3"
-            # Below libs are direct dependencies of libsatlas
-            LIBQUADMATH_PATH="/lib64/libquadmath.so.0"
-    fi
-    MAYBE_LIB64=lib64
-elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
-    LIBGOMP_PATH="/usr/lib/x86_64-linux-gnu/libgomp.so.1"
-    LIBNUMA_PATH="/usr/lib/x86_64-linux-gnu/libnuma.so.1"
-    LIBELF_PATH="/usr/lib/x86_64-linux-gnu/libelf.so.1"
-    if [[ $ROCM_INT -ge 50300 ]]; then
-        LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.6"
-    else
-        LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.5"
-    fi
-    LIBDRM_PATH="/usr/lib/x86_64-linux-gnu/libdrm.so.2"
-    LIBDRM_AMDGPU_PATH="/usr/lib/x86_64-linux-gnu/libdrm_amdgpu.so.1"
-    if [[ $ROCM_INT -ge 60100 && $ROCM_INT -lt 60300 ]]; then
-        # Below libs are direct dependencies of libhipsolver
-        LIBCHOLMOD_PATH="/lib/x86_64-linux-gnu/libcholmod.so.3"
-        # Below libs are direct dependencies of libcholmod
-        LIBSUITESPARSE_CONFIG_PATH="/lib/x86_64-linux-gnu/libsuitesparseconfig.so.5"
-        LIBAMD_PATH="/lib/x86_64-linux-gnu/libamd.so.2"
-        LIBCAMD_PATH="/lib/x86_64-linux-gnu/libcamd.so.2"
-        LIBCCOLAMD_PATH="/lib/x86_64-linux-gnu/libccolamd.so.2"
-        LIBCOLAMD_PATH="/lib/x86_64-linux-gnu/libcolamd.so.2"
-        LIBMETIS_PATH="/lib/x86_64-linux-gnu/libmetis.so.5"
-        LIBLAPACK_PATH="/lib/x86_64-linux-gnu/liblapack.so.3"
-        LIBBLAS_PATH="/lib/x86_64-linux-gnu/libblas.so.3"
-        # Below libs are direct dependencies of libblas
-        LIBGFORTRAN_PATH="/lib/x86_64-linux-gnu/libgfortran.so.5"
-        LIBQUADMATH_PATH="/lib/x86_64-linux-gnu/libquadmath.so.0"
-    fi
-    MAYBE_LIB64=lib
-fi
-OS_SO_PATHS=($LIBGOMP_PATH $LIBNUMA_PATH\
-             $LIBELF_PATH $LIBTINFO_PATH\
-             $LIBDRM_PATH $LIBDRM_AMDGPU_PATH\
-             $LIBSUITESPARSE_CONFIG_PATH\
-             $LIBCHOLMOD_PATH $LIBAMD_PATH\
-             $LIBCAMD_PATH $LIBCCOLAMD_PATH\
-             $LIBCOLAMD_PATH $LIBSATLAS_PATH\
-             $LIBGFORTRAN_PATH $LIBQUADMATH_PATH\
-             $LIBMETIS_PATH $LIBLAPACK_PATH\
-             $LIBBLAS_PATH)
-OS_SO_FILES=()
-for lib in "${OS_SO_PATHS[@]}"
-do
-    file_name="${lib##*/}" # Substring removal of path to get filename
-    OS_SO_FILES[${#OS_SO_FILES[@]}]=$file_name # Append lib to array
-done
-
-# rocBLAS library files
-ROCBLAS_LIB_SRC=$ROCM_HOME/lib/rocblas/library
-ROCBLAS_LIB_DST=lib/rocblas/library
-ARCH=$(echo $PYTORCH_ROCM_ARCH | sed 's/;/|/g') # Replace ; seperated arch list to bar for grep
-ARCH_SPECIFIC_FILES=$(ls $ROCBLAS_LIB_SRC | grep -E $ARCH)
-OTHER_FILES=$(ls $ROCBLAS_LIB_SRC | grep -v gfx)
-ROCBLAS_LIB_FILES=($ARCH_SPECIFIC_FILES $OTHER_FILES)
-
-# hipblaslt library files
-HIPBLASLT_LIB_SRC=$ROCM_HOME/lib/hipblaslt/library
-HIPBLASLT_LIB_DST=lib/hipblaslt/library
-ARCH_SPECIFIC_FILES=$(ls $HIPBLASLT_LIB_SRC | grep -E $ARCH)
-OTHER_FILES=$(ls $HIPBLASLT_LIB_SRC | grep -v gfx)
-HIPBLASLT_LIB_FILES=($ARCH_SPECIFIC_FILES $OTHER_FILES)
-
-# ROCm library files
-# Overwrite ROCM_SO_FILES to contain only libmagma.so if BUILD_LIGHTWEIGHT is enabled
-if [[ "$BUILD_LIGHTWEIGHT" == "1" ]]; then
-    LIGHTWEIGHT_ROCM_SO_FILES=(
-        "libmagma.so"
-    )
-fi
-
 do_lightweight_build() {
     echo "=== Building LIGHTWEIGHT variant ==="
+
+    # ROCm library files
+    LIGHTWEIGHT_ROCM_SO_FILES=(
+        # Minimal set for lightweight
+        "libmagma.so"
+    )
 
     # First, gather actual file paths for the minimal set
     ROCM_SO_PATHS_LIGHTWEIGHT=()
@@ -254,6 +116,7 @@ do_lightweight_build() {
     else
         BUILD_SCRIPT=build_libtorch.sh
     fi
+    export WHEELNAME_MARKER="lw" 
     source "$SCRIPTPATH/${BUILD_SCRIPT}"
 
     echo "=== Done building LIGHTWEIGHT variant ==="
@@ -262,6 +125,136 @@ do_lightweight_build() {
 # 2) HEAVYWEIGHT BUILD
 do_heavyweight_build() {
     echo "=== Building HEAVYWEIGHT variant ==="
+
+    HEAVYWEIGHT_ROCM_SO_FILES=(
+        # Full set for heavyweight
+        "libMIOpen.so"
+        "libamdhip64.so"
+        "libhipblas.so"
+        "libhipblaslt.so"
+        "libhipfft.so"
+        "libhiprand.so"
+        "libhipsolver.so"
+        "libhipsparse.so"
+        "libhsa-runtime64.so"
+        "libhiprtc.so"
+        "libamd_comgr.so"
+        "libmagma.so"
+        "librccl.so"
+        "librocblas.so"
+        "librocfft.so"
+        "librocm_smi64.so"
+        "librocrand.so"
+        "librocsolver.so"
+        "librocsparse.so"
+        "libroctracer64.so"
+        "libroctx64.so"
+    )
+    
+    # Adjust list based on ROCm version
+    if [[ $ROCM_INT -ge 60100 ]]; then
+        HEAVYWEIGHT_ROCM_SO_FILES+=("librocprofiler-register.so")
+    fi
+    if [[ $ROCM_INT -ge 60200 ]]; then
+        HEAVYWEIGHT_ROCM_SO_FILES+=("librocm-core.so")
+    fi
+    
+    
+    
+    OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+    if [[ "$OS_NAME" == *"CentOS Linux"* || "$OS_NAME" == *"AlmaLinux"* ]]; then
+        LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
+        LIBNUMA_PATH="/usr/lib64/libnuma.so.1"
+        LIBELF_PATH="/usr/lib64/libelf.so.1"
+        if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+            LIBTINFO_PATH="/usr/lib64/libtinfo.so.5"
+        else
+            LIBTINFO_PATH="/usr/lib64/libtinfo.so.6"
+        fi
+        LIBDRM_PATH="/opt/amdgpu/lib64/libdrm.so.2"
+        LIBDRM_AMDGPU_PATH="/opt/amdgpu/lib64/libdrm_amdgpu.so.1"
+        if [[ $ROCM_INT -ge 60100 && $ROCM_INT -lt 60300 ]]; then
+            # Below libs are direct dependencies of libhipsolver
+            LIBSUITESPARSE_CONFIG_PATH="/lib64/libsuitesparseconfig.so.4"
+            if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+                LIBCHOLMOD_PATH="/lib64/libcholmod.so.2"
+                # Below libs are direct dependencies of libsatlas
+                LIBGFORTRAN_PATH="/lib64/libgfortran.so.3"
+            else
+                LIBCHOLMOD_PATH="/lib64/libcholmod.so.3"
+                # Below libs are direct dependencies of libsatlas
+                LIBGFORTRAN_PATH="/lib64/libgfortran.so.5"
+            fi
+                # Below libs are direct dependencies of libcholmod
+                LIBAMD_PATH="/lib64/libamd.so.2"
+                LIBCAMD_PATH="/lib64/libcamd.so.2"
+                LIBCCOLAMD_PATH="/lib64/libccolamd.so.2"
+                LIBCOLAMD_PATH="/lib64/libcolamd.so.2"
+                LIBSATLAS_PATH="/lib64/atlas/libsatlas.so.3"
+                # Below libs are direct dependencies of libsatlas
+                LIBQUADMATH_PATH="/lib64/libquadmath.so.0"
+        fi
+        MAYBE_LIB64=lib64
+    elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
+        LIBGOMP_PATH="/usr/lib/x86_64-linux-gnu/libgomp.so.1"
+        LIBNUMA_PATH="/usr/lib/x86_64-linux-gnu/libnuma.so.1"
+        LIBELF_PATH="/usr/lib/x86_64-linux-gnu/libelf.so.1"
+        if [[ $ROCM_INT -ge 50300 ]]; then
+            LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.6"
+        else
+            LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.5"
+        fi
+        LIBDRM_PATH="/usr/lib/x86_64-linux-gnu/libdrm.so.2"
+        LIBDRM_AMDGPU_PATH="/usr/lib/x86_64-linux-gnu/libdrm_amdgpu.so.1"
+        if [[ $ROCM_INT -ge 60100 && $ROCM_INT -lt 60300 ]]; then
+            # Below libs are direct dependencies of libhipsolver
+            LIBCHOLMOD_PATH="/lib/x86_64-linux-gnu/libcholmod.so.3"
+            # Below libs are direct dependencies of libcholmod
+            LIBSUITESPARSE_CONFIG_PATH="/lib/x86_64-linux-gnu/libsuitesparseconfig.so.5"
+            LIBAMD_PATH="/lib/x86_64-linux-gnu/libamd.so.2"
+            LIBCAMD_PATH="/lib/x86_64-linux-gnu/libcamd.so.2"
+            LIBCCOLAMD_PATH="/lib/x86_64-linux-gnu/libccolamd.so.2"
+            LIBCOLAMD_PATH="/lib/x86_64-linux-gnu/libcolamd.so.2"
+            LIBMETIS_PATH="/lib/x86_64-linux-gnu/libmetis.so.5"
+            LIBLAPACK_PATH="/lib/x86_64-linux-gnu/liblapack.so.3"
+            LIBBLAS_PATH="/lib/x86_64-linux-gnu/libblas.so.3"
+            # Below libs are direct dependencies of libblas
+            LIBGFORTRAN_PATH="/lib/x86_64-linux-gnu/libgfortran.so.5"
+            LIBQUADMATH_PATH="/lib/x86_64-linux-gnu/libquadmath.so.0"
+        fi
+        MAYBE_LIB64=lib
+    fi
+    OS_SO_PATHS=($LIBGOMP_PATH $LIBNUMA_PATH\
+                 $LIBELF_PATH $LIBTINFO_PATH\
+                 $LIBDRM_PATH $LIBDRM_AMDGPU_PATH\
+                 $LIBSUITESPARSE_CONFIG_PATH\
+                 $LIBCHOLMOD_PATH $LIBAMD_PATH\
+                 $LIBCAMD_PATH $LIBCCOLAMD_PATH\
+                 $LIBCOLAMD_PATH $LIBSATLAS_PATH\
+                 $LIBGFORTRAN_PATH $LIBQUADMATH_PATH\
+                 $LIBMETIS_PATH $LIBLAPACK_PATH\
+                 $LIBBLAS_PATH)
+    OS_SO_FILES=()
+    for lib in "${OS_SO_PATHS[@]}"
+    do
+        file_name="${lib##*/}" # Substring removal of path to get filename
+        OS_SO_FILES[${#OS_SO_FILES[@]}]=$file_name # Append lib to array
+    done
+    
+    # rocBLAS library files
+    ROCBLAS_LIB_SRC=$ROCM_HOME/lib/rocblas/library
+    ROCBLAS_LIB_DST=lib/rocblas/library
+    ARCH=$(echo $PYTORCH_ROCM_ARCH | sed 's/;/|/g') # Replace ; seperated arch list to bar for grep
+    ARCH_SPECIFIC_FILES=$(ls $ROCBLAS_LIB_SRC | grep -E $ARCH)
+    OTHER_FILES=$(ls $ROCBLAS_LIB_SRC | grep -v gfx)
+    ROCBLAS_LIB_FILES=($ARCH_SPECIFIC_FILES $OTHER_FILES)
+    
+    # hipblaslt library files
+    HIPBLASLT_LIB_SRC=$ROCM_HOME/lib/hipblaslt/library
+    HIPBLASLT_LIB_DST=lib/hipblaslt/library
+    ARCH_SPECIFIC_FILES=$(ls $HIPBLASLT_LIB_SRC | grep -E $ARCH)
+    OTHER_FILES=$(ls $HIPBLASLT_LIB_SRC | grep -v gfx)
+    HIPBLASLT_LIB_FILES=($ARCH_SPECIFIC_FILES $OTHER_FILES)
 
     # Gather file paths for the full set
     ROCM_SO_PATHS_HEAVYWEIGHT=()
@@ -280,9 +273,10 @@ do_heavyweight_build() {
 	ROCM_SO_PATHS_HEAVYWEIGHT[${#ROCM_SO_PATHS_HEAVYWEIGHT[@]}]="$file_path" # Append lib to array
     done
 
-    # Add OS libraries
     DEPS_LIST=(${ROCM_SO_PATHS_HEAVYWEIGHT[*]})
     DEPS_SONAME=(${HEAVYWEIGHT_ROCM_SO_FILES[*]})
+    # Add OS libraries
+    DEPS_SONAME+=(${OS_SO_FILES[*]})
 
     DEPS_AUX_SRCLIST=()
     DEPS_AUX_SRCLIST+=("${ROCBLAS_LIB_FILES[@]/#/$ROCBLAS_LIB_SRC/}")
@@ -325,6 +319,7 @@ do_heavyweight_build() {
     else
         BUILD_SCRIPT=build_libtorch.sh
     fi
+    export WHEELNAME_MARKER="hw" 
     source "$SCRIPTPATH/${BUILD_SCRIPT}"
 
     echo "=== Done building HEAVYWEIGHT variant ==="

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -362,7 +362,7 @@ fi
 
 echo "PYTORCH_ROCM_ARCH: ${PYTORCH_ROCM_ARCH}"
 
-export LIGHTWEIGHT_WHEELNAME_MARKER=".lw"
+export LIGHTWEIGHT_WHEELNAME_MARKER="${LIGHTWEIGHT_WHEELNAME_MARKER}"
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 if [[ -z "$BUILD_PYTHONLESS" ]]; then
     BUILD_SCRIPT=build_torch_wheel.sh	

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -116,7 +116,7 @@ do_lightweight_build() {
     else
         BUILD_SCRIPT=build_libtorch.sh
     fi
-    export WHEELNAME_MARKER="lw" 
+    export WHEELNAME_MARKER="${LIGHTWEIGHT_WHEELNAME_MARKER}" 
     source "$SCRIPTPATH/${BUILD_SCRIPT}"
 
     echo "=== Done building LIGHTWEIGHT variant ==="
@@ -319,7 +319,7 @@ do_heavyweight_build() {
     else
         BUILD_SCRIPT=build_libtorch.sh
     fi
-    export WHEELNAME_MARKER="hw" 
+    export WHEELNAME_MARKER=""
     source "$SCRIPTPATH/${BUILD_SCRIPT}"
 
     echo "=== Done building HEAVYWEIGHT variant ==="
@@ -362,6 +362,7 @@ fi
 
 echo "PYTORCH_ROCM_ARCH: ${PYTORCH_ROCM_ARCH}"
 
+export LIGHTWEIGHT_WHEELNAME_MARKER=".lw"
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 if [[ -z "$BUILD_PYTHONLESS" ]]; then
     BUILD_SCRIPT=build_torch_wheel.sh	

--- a/manywheel/build_torch_wheel.sh
+++ b/manywheel/build_torch_wheel.sh
@@ -271,11 +271,12 @@ echo 'Built this wheel:'
 ls /tmp/$WHEELHOUSE_DIR
 mkdir -p "/$WHEELHOUSE_DIR"
 torch_wheel=$(ls /tmp/$WHEELHOUSE_DIR/torch*linux*.whl | head -n1)
+# Place wheels in separate directories to distinguish them in build_common.sh
 if [ "${BUILD_LIGHTWEIGHT}" == "1" ]; then
-  cp $torch_wheel "/${WHEELHOUSE_DIR}/$(basename $torch_wheel | sed 's/\.git/.lw.git/')"
+  cp $torch_wheel "/${WHEELHOUSE_DIR}/${LIGHTWEIGHT_WHEELNAME_MARKER}/"
 fi
 if [ "${BUILD_HEAVYWEIGHT}" == "1" ]; then
-  cp $torch_wheel "/${WHEELHOUSE_DIR}/$(basename $torch_wheel | sed 's/\.git/.hw.git/')"
+  cp $torch_wheel "/${WHEELHOUSE_DIR}/"
 fi
 rm $torch_wheel
 

--- a/manywheel/build_torch_wheel.sh
+++ b/manywheel/build_torch_wheel.sh
@@ -63,10 +63,10 @@ fi
 if [[ -z "$build_number" ]]; then
     build_number=1
 fi
-if [[ "$BUILD_LIGHTWEIGHT" == "1" ]]; then
-    build_version="${build_version}.lw"
-    export BUILD_LIGHTWEIGHT=0
-fi
+# TODO: Commenting for now so that the common wheel built does not have ".lw" in the name/version
+#if [[ "$BUILD_LIGHTWEIGHT" == "1" ]]; then
+#    build_version="${build_version}.lw"
+#fi
 
 if [[ -z "$PYTORCH_ROOT" ]]; then
     echo "Need to set PYTORCH_ROOT env variable"
@@ -270,7 +270,14 @@ popd
 echo 'Built this wheel:'
 ls /tmp/$WHEELHOUSE_DIR
 mkdir -p "/$WHEELHOUSE_DIR"
-mv /tmp/$WHEELHOUSE_DIR/torch*linux*.whl /$WHEELHOUSE_DIR/
+torch_wheel=$(ls /tmp/$WHEELHOUSE_DIR/torch*linux*.whl | head -n1)
+if [ "${BUILD_LIGHTWEIGHT}" == "1" ]; then
+  cp $torch_wheel "/${WHEELHOUSE_DIR}/$(basename $torch_wheel | sed 's/\.git/.lw.git/')"
+fi
+if [ "${BUILD_HEAVYWEIGHT}" == "1" ]; then
+  cp $torch_wheel "/${WHEELHOUSE_DIR}/$(basename $torch_wheel | sed 's/\.git/.hw.git/')"
+fi
+rm $torch_wheel
 
 if [[ "$USE_SPLIT_BUILD" == "true" ]]; then
     mv /tmp/$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/ || true

--- a/manywheel/build_torch_wheel.sh
+++ b/manywheel/build_torch_wheel.sh
@@ -273,6 +273,7 @@ mkdir -p "/$WHEELHOUSE_DIR"
 torch_wheel=$(ls /tmp/$WHEELHOUSE_DIR/torch*linux*.whl | head -n1)
 # Place wheels in separate directories to distinguish them in build_common.sh
 if [ "${BUILD_LIGHTWEIGHT}" == "1" ]; then
+  mkdir -p "/${WHEELHOUSE_DIR}/${LIGHTWEIGHT_WHEELNAME_MARKER}/"
   cp $torch_wheel "/${WHEELHOUSE_DIR}/${LIGHTWEIGHT_WHEELNAME_MARKER}/"
 fi
 if [ "${BUILD_HEAVYWEIGHT}" == "1" ]; then


### PR DESCRIPTION
Highlights:
* `LIGHTWEIGHT_WHEELNAME_MARKER` env var passed in from rocAutomation `build_wheel.sh` (part of https://github.com/ROCm/rocAutomation/pull/759)
* `do_lightweight_build` sets `WHEELNAME_MARKER` env var to `LIGHTWEIGHT_WHEELNAME_MARKER`, whereas `do_heavyweight_build` sets it to empty string
* `build_torch_wheel.sh` will only build one (lightweight) pytorch wheel, but without modifying the `build_version` (so that `torch` package doesn't self-report version as `.lw`)
* `build_torch_wheel.sh` copies the lightweight wheel into an `.lw` subdirectory (makes it easy to pick up lw/hw wheel exclusively in the `build_common.sh` logic:
`for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/${WHEELNAME_MARKER}/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip; do`
* `build_common.sh` is responsible for all name/content modification for wheels
--- it modifies the dist-info directory to introduce `.lw` in the name for lightweight wheel
--- it updates the `METADATA` file Version to introduce `.lw` in the name for lightweight wheel
--- this ensures that the wheel is pip installable, otherwise pip complains of mismatching metadata if wheel has `.lw` in the name
--- Publish both lightweight and heavyweight wheels in /final_pkgs directory

Validation: http://ml-ci-internal.amd.com:8080/blue/organizations/jenkins/pytorch%2Fmanylinux_rocm_wheels/detail/manylinux_rocm_wheels/643/pipeline/194