### PR TITLE
[main] Fix 2.8

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -332,7 +332,7 @@ do_heavyweight_build() {
 
 ver() {
     # Convert dotted version string "x.y.z" into zero-padded numeric for comparison
-    printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ')
+    printf '%d%03d%03d%03d' $(echo "$1" | tr '.' ' ')
 }
 
 # Add triton install dependency


### PR DESCRIPTION
Failure
http://rocm-ci.amd.com/job/rocm-pytorch-manylinux-wheel-builder/1970/parameters/
Basically bash internally tries to parse 002008000000 as an octal literal (because of the leading 0). But octal only allows digits 0–7, so the 8 in 008 is invalid. To fix this we strip the leading zero (so bash treats it as decimal)
```
[2025-05-08T11:27:34.899Z] ++ printf %03d%03d%03d%03d 2 5
[2025-05-08T11:27:34.899Z] + [[ 002008000000 -ge 002005000000 ]]
[2025-05-08T11:27:34.899Z] /builder/manywheel/build_rocm.sh: line 346: [[: 002008000000: value too great for base (error token is "002008000000")
[2025-05-08T11:27:34.899Z] ++ cut -c1-8 /pytorch/.ci/docker/ci_commit_pins/triton-rocm.txt
[2025-05-08T11:27:34.899Z] cut: /pytorch/.ci/docker/ci_commit_pins/triton-rocm.txt: No such file or directory
[2025-05-08T11:27:34.899Z] + TRITON_SHORTHASH=
```
Validation
http://rocm-ci.amd.com/job/mainline-pytorch_internal-manylinux-wheels/56/