### PR TITLE
Add rocroller lib to pytorch wheel dependencies

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -149,6 +149,7 @@ do_heavyweight_build() {
         "librocsparse.so"
         "libroctracer64.so"
         "libroctx64.so"
+	"librocroller.so"
     )
     
     # Adjust list based on ROCm version


### PR DESCRIPTION
hipblasLT dependency on rocroller has made it into mainline as of build 16233 at least, as evidenced by
http://rocm-ci.amd.com/blue/organizations/jenkins/rocm-pytorch-manylinux-wheel-builder/detail/rocm-pytorch-manylinux-wheel-builder/2914/pipeline/143