### PR TITLE
[add_rocroller] Update magma install instructions for ROCm7.0 (#80)

### DIFF
--- a/common/install_rocm_magma.sh
+++ b/common/install_rocm_magma.sh
@@ -23,13 +23,11 @@ esac
 MKLROOT=${MKLROOT:-/opt/intel}
 
 # "install" hipMAGMA into /opt/rocm/magma by copying after build
-git clone https://bitbucket.org/icl/magma.git
+git clone https://github.com/ROCm/utk-magma.git -b release/2.9.0_rocm70 magma
 pushd magma
-if [[ $PYTORCH_BRANCH == "release/1.10.1" ]]; then
-    git checkout magma_ctrl_launch_bounds
-else
-    git checkout a1625ff4d9bc362906bd01f805dbbe12612953f6
-fi
+# version 2.9 + ROCm 7.0 related updates
+git checkout 91c4f720a17e842b364e9de41edeef76995eb9ad
+
 cp make.inc-examples/make.inc.hip-gcc-mkl make.inc
 echo 'LIBDIR += -L$(MKLROOT)/lib' >> make.inc
 # TODO (1)


### PR DESCRIPTION
Fixes errors such as:
```
14:59:22  [0m[91msrc/xhsgetrf_gpu.cpp:403:21: error: no matching function for call to 'hipblasGemmEx'
14:59:22    403 |                     hipblasGemmEx( queues[1]->hipblas_handle(),
14:59:22        |                     ^~~~~~~~~~~~~
14:59:22  [0m[91m/opt/rocm-7.0.0/lib/llvm/bin/../../../include/hipblas/hipblas.h:31119:32: note: candidate function not viable: no known conversion from 'hipDataType' to 'hipblasDatatype_t' for 9th argument
```
when building Magma.