### PR TITLE
Do not explicitly bundle magma lib into PyTorch wheels

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -3,7 +3,6 @@
 set -ex
 
 export ROCM_HOME=/opt/rocm
-export MAGMA_HOME=$ROCM_HOME/magma
 # TODO: libtorch_cpu.so is broken when building with Debug info
 export BUILD_DEBUG_INFO=0
 
@@ -80,7 +79,6 @@ do_lightweight_build() {
     # ROCm library files
     LIGHTWEIGHT_ROCM_SO_FILES=(
         # Minimal set for lightweight
-        "libmagma.so"
     )
 
     # First, gather actual file paths for the minimal set
@@ -139,7 +137,6 @@ do_heavyweight_build() {
         "libhsa-runtime64.so"
         "libhiprtc.so"
         "libamd_comgr.so"
-        "libmagma.so"
         "librccl.so"
         "librocblas.so"
         "librocfft.so"


### PR DESCRIPTION
Let the CMake build flow handle it as per https://github.com/ROCm/pytorch/pull/2233 and https://github.com/ROCm/rocAutomation/pull/990