### PR TITLE
[main] turn on INSTALL_TEST

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -13,7 +13,7 @@ export USE_STATIC_CUDNN=1
 export USE_STATIC_NCCL=1
 export ATEN_STATIC_CUDA=1
 export USE_CUDA_STATIC_LINK=1
-export INSTALL_TEST=0 # dont install test binaries into site-packages
+export INSTALL_TEST=1 # dont install test binaries into site-packages
 # Set RPATH instead of RUNPATH when using patchelf to avoid LD_LIBRARY_PATH override
 export FORCE_RPATH="--force-rpath"
 


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-541260

Turns on https://github.com/ROCm/builder/blob/main/manywheel/build_rocm.sh#L16 to install binarys needed for certain test suites that are generated during the build but not usually included in the runtime wheels. 
