### PR TITLE
[main] Conditionalize triton package name on rocm version

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -359,7 +359,7 @@ if [ ${PYTORCH_VERSION%%\.*} -ge 2 ]; then
         TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'$(if [[ $(ver "$PYTORCH_VERSION") -le $(ver "2.5") ]]; then echo " and python_version < '3.13'"; fi)"
         # Use "triton" for dev builds, else "pytorch-triton-rocm"
 		# Temp: Currently enabling for rocm7.1_internal_testing branch only but plan to expand it to other branches
-        if [[ "$PYTORCH_VERSION_FULL" == *"2.9.0a0"* ]]; then
+        if [[ "$PYTORCH_VERSION_FULL" == *"2.9.0a0"* && $ROCM_INT -gt 70000 ]]; then
             PKG="triton"
         else
             PKG="pytorch-triton-rocm"

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -359,7 +359,7 @@ if [ ${PYTORCH_VERSION%%\.*} -ge 2 ]; then
         TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'$(if [[ $(ver "$PYTORCH_VERSION") -le $(ver "2.5") ]]; then echo " and python_version < '3.13'"; fi)"
         # Use "triton" for dev builds, else "pytorch-triton-rocm"
 		# Temp: Currently enabling for rocm7.1_internal_testing branch only but plan to expand it to other branches
-        if [[ "$PYTORCH_VERSION_FULL" == *"2.9.0a0"* && $ROCM_INT -gt 70000 ]]; then
+        if [[ $ROCM_INT -gt 70000 ]]; then
             PKG="triton"
         else
             PKG="pytorch-triton-rocm"


### PR DESCRIPTION
relates to https://github.com/ROCm/pytorch/pull/2518
Release 7.0: http://rocm-ci.amd.com/job/pytorch2.6-manylinux-wheels_rel-7.0/40/
`pytorch_triton_rocm-3.2.0+rocm7.0.0.git20943800-cp313-cp313-linux_x86_64.whl pushed to http://compute-artifactory.amd.com/artifactory/compute-pytorch-rocm/compute-rocm-rel-7.0/6/triton_main_conditionalize/pytorch_triton_rocm-3.2.0+rocm7.0.0.git20943800-cp313-cp313-linux_x86_64.whl`
Mainline: http://rocm-ci.amd.com/job/mainline-pytorch2.6-manylinux-wheels/244/
`triton-3.2.0+rocm7.1.0.git20943800-cp313-cp313-linux_x86_64.whl pushed to http://compute-artifactory.amd.com/artifactory/compute-pytorch-rocm/compute-rocm-dkms-no-npi-hipclang/16516/triton_main_conditionalize/triton-3.2.0+rocm7.1.0.git20943800-cp313-cp313-linux_x86_64.whl`