### PR TITLE
Fix for SWDEV-550252, remove not working link

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -92,8 +92,7 @@ RUN yum install -y \
         glibc-langpack-en
 
 # ius-release package needs epel-release-7
-RUN ls -lrt /etc/yum.repos.d/ && \
-    yum install -y \
+RUN yum install -y \
     https://vault.ius.io/el7/x86_64/packages/i/ius-release-2-1.el7.ius.noarch.rpm \
     https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm
 #Stopped working as of 8/1 (due to CentOS EOL?)


### PR DESCRIPTION
Fix for http://rocm-ci.amd.com/job/rocm-pytorch-manylinux-wheel-builder/5866/console

```
13:34:23  #16 [common  5/20] RUN yum install -y     https://repo.ius.io/ius-release-el7.rpm     https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm
13:34:23  #16 1.024 Last metadata expiration check: 0:25:31 ago on Mon 18 Aug 2025 07:38:51 AM UTC.
13:34:23  #16 2.096 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)
13:34:23  #16 2.107 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)
13:34:23  #16 2.113 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)
13:34:23  #16 2.117 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)
13:34:23  #16 2.117 [FAILED] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)
13:34:23  #16 2.122 Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)
13:34:23  #16 ERROR: process "/bin/sh -c yum install -y     https://repo.ius.io/ius-release-el7.rpm     https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm" did not complete successfully: exit code: 1
```