### PR TITLE
[main] Handle ius repo deprecation; move from gcc11 to gcc13

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -359,7 +359,7 @@ if [ ${PYTORCH_VERSION%%\.*} -ge 2 ]; then
         TRITON_CONSTRAINT="platform_system == 'Linux' and platform_machine == 'x86_64'$(if [[ $(ver "$PYTORCH_VERSION") -le $(ver "2.5") ]]; then echo " and python_version < '3.13'"; fi)"
         # Use "triton" for dev builds, else "pytorch-triton-rocm"
 		# Temp: Currently enabling for rocm7.1_internal_testing branch only but plan to expand it to other branches
-        if [[ "$PYTORCH_VERSION_FULL" == *"2.9.0a0"* ]]; then
+        if [[ $ROCM_INT -gt 70000 ]]; then
             PKG="triton"
         else
             PKG="pytorch-triton-rocm"


### PR DESCRIPTION
taking from https://github.com/pytorch/pytorch/commit/6ae7730eebffbcaa838d46401be0af1173b80b4a#diff-52db6ea5d85b5fa9235ba3633dd5a5408f829eb4da5b112aed23b7f9de5e200f

validation job: http://rocm-ci.amd.com/job/pytorch-manylinux-wheel-builder_rel-7.0/1013/
Resolves https://ontrack-internal.amd.com/browse/SWDEV-550252
http://rocm-ci.amd.com/view/Release-7.0/job/pytorch2.6-manylinux-wheels_rel-7.0/45/

Fixing : http://rocm-ci.amd.com/blue/organizations/jenkins/pytorch-manylinux-wheel-builder_rel-7.0/detail/pytorch-```
```
manylinux-wheel-builder_rel-7.0/993/pipeline/123
[2025-08-18T09:19:18.842Z] #15 [common  5/20] RUN yum install -y     https://repo.ius.io/ius-release-el7.rpm     https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm

[2025-08-18T09:19:19.406Z] #15 0.489 Last metadata expiration check: 5:57:11 ago on Mon 18 Aug 2025 03:22:08 AM UTC.

[2025-08-18T09:19:19.967Z] #15 1.065 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:19.967Z] #15 1.070 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:19.967Z] #15 1.074 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:19.967Z] #15 1.078 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:19.967Z] #15 1.078 [FAILED] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:19.967Z] #15 1.082 Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:20.223Z] #15 ERROR: process "/bin/sh -c yum install -y     https://repo.ius.io/ius-release-el7.rpm     https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm" did not complete successfully: exit code: 1

[2025-08-18T09:19:20.223Z] 

[2025-08-18T09:19:20.223Z] #11 [base 1/4] FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:6f42f4382bc73e9584206e6722e001922c0d4846c932fccaa04c0e35903b717d

[2025-08-18T09:19:20.223Z] #11 sha256:1a4c282d288c558955eaa809522b305b1dc3c458ee448b452919ef62f4f8b792 218.70MB / 218.70MB 11.0s done

[2025-08-18T09:19:20.223Z] #11 extracting sha256:2eae4ad0bb479b2c22340b64ff37f0785ad235725fe1146676ffde84ed609cb1 0.2s done

[2025-08-18T09:19:20.223Z] #11 extracting sha256:f30ef9f5bd1e45925733212eb2246ba12de671c9e461ef3f1f267ba18fa24c51 done

[2025-08-18T09:19:20.223Z] #11 extracting sha256:1a4c282d288c558955eaa809522b305b1dc3c458ee448b452919ef62f4f8b792 4.2s

[2025-08-18T09:19:20.223Z] ------

[2025-08-18T09:19:20.223Z]  > [common  5/20] RUN yum install -y     https://repo.ius.io/ius-release-el7.rpm     https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm:

[2025-08-18T09:19:20.223Z] 0.489 Last metadata expiration check: 5:57:11 ago on Mon 18 Aug 2025 03:22:08 AM UTC.

[2025-08-18T09:19:20.223Z] 1.065 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:20.223Z] 1.070 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:20.223Z] 1.074 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:20.223Z] 1.078 [MIRROR] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:20.223Z] 1.078 [FAILED] ius-release-el7.rpm: Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:20.223Z] 1.082 Status code: 404 for https://repo.ius.io/ius-release-el7.rpm (IP: 96.6.228.101)

[2025-08-18T09:19:20.223Z] ------

[2025-08-18T09:19:20.223Z] ERROR: failed to solve: process "/bin/sh -c yum install -y     https://repo.ius.io/ius-release-el7.rpm     https://ossci-linux.s3.amazonaws.com/epel-release-7-14.noarch.rpm" did not complete successfully: exit code: 1

script returned exit code 1
```

```