### PR TITLE
[DO NOT CHERRY PICK][rocm7.0]Fix setuptools

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -12,8 +12,8 @@ RUN yum install -y wget curl perl util-linux xz bzip2 git patch which perl zlib-
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 # Install setuptools and wheel for python 3.12/3.13
-RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
-    /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
+RUN for cpython_version in "cp310-cp310" "cp311-cp311" "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
+    /opt/python/${cpython_version}/bin/python -m pip install setuptools==79.0.1 wheel; \
     done;
 
 # cmake-3.18.4 from pip


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-551662
Setuptools not found error 

We want to pin setuptools at 79.0.1 because upstream has pinned setuptools between 70 and 80. Brought in by https://github.com/pytorch/pytorch/pull/153052
In this rocm7.0 branch we are pinning via the dockerfile but in the main branch we will install requirements.txt before calling `python setup.py clean`
`setuptools>=70.1.0,<80.0  # setuptools develop deprecated on 80.0`

Validation: http://rocm-ci.amd.com/job/mainline-pytorch2.8-manylinux-wheels/104/
