### PR TITLE
[main] install requirements.txt before setup.py

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -12,8 +12,8 @@ RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl 
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 # Install setuptools and wheel for python 3.12/3.13
-RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
-    /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
+RUN for cpython_version in "cp310-cp310" "cp311-cp311" "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
+    /opt/python/${cpython_version}/bin/python -m pip install setuptools==79.0.1 wheel; \
     done;
 
 # cmake-3.18.4 from pip

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -12,8 +12,8 @@ RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl 
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 # Install setuptools and wheel for python 3.12/3.13
-RUN for cpython_version in "cp310-cp310" "cp311-cp311" "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
-    /opt/python/${cpython_version}/bin/python -m pip install setuptools==79.0.1 wheel; \
+RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
+    /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
     done;
 
 # cmake-3.18.4 from pip

--- a/manywheel/build_torch_wheel.sh
+++ b/manywheel/build_torch_wheel.sh
@@ -132,7 +132,6 @@ fi
 pushd "$PYTORCH_ROOT"
 pip install -r requirements.txt
 python setup.py clean
-retry pip install -r requirements.txt
 
 # ROCm RHEL8 packages are built with cxx11 abi symbols
 if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* || "$DESIRED_CUDA" == *"rocm"* ]]; then

--- a/manywheel/build_torch_wheel.sh
+++ b/manywheel/build_torch_wheel.sh
@@ -130,6 +130,7 @@ fi
 #######################################################
 
 pushd "$PYTORCH_ROOT"
+pip install -r requirements.txt
 python setup.py clean
 retry pip install -r requirements.txt
 


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-551662
Setuptools not found error 

We want to pin setuptools at 79.0.1 because upstream has pinned setuptools between 70 and 80. Brought in by https://github.com/pytorch/pytorch/pull/153052
we will install requirements.txt before calling `python setup.py clean`
`setuptools>=70.1.0,<80.0  # setuptools develop deprecated on 80.0`

http://rocm-ci.amd.com/job/mainline-pytorch2.8-manylinux-wheels/110/