### PR TITLE
[rocm7.2] Upgrade cmake version to 3.28.4

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -18,7 +18,7 @@ RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
 
 # cmake-3.18.4 from pip
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.18.4 && \
+    python3 -mpip install cmake==3.18.4.post1 && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake3
 
 FROM base as openssl
@@ -127,7 +127,7 @@ ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/op
 
 # cmake-3.18.4 from pip; force in case cmake3 already exists
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.18.4 && \
+    python3 -mpip install cmake==3.18.4.post1 && \
     ln -sf /usr/local/bin/cmake /usr/bin/cmake3
 
 FROM cpu_final as cuda_final

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -18,6 +18,7 @@ RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
 
 # cmake-3.28.4 from pip
 RUN yum install -y python3-pip && \
+    python3 -m pip install --upgrade pip && \
     python3 -mpip install cmake==3.28.4 && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake3
 

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -16,9 +16,9 @@ RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
     /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
     done;
 
-# cmake-3.18.4 from pip
+# cmake-3.28.4 from pip
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.18.4.post1 && \
+    python3 -mpip install cmake==3.28.4 && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake3
 
 FROM base as openssl
@@ -125,9 +125,9 @@ ARG DEVTOOLSET_VERSION=13
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 
-# cmake-3.18.4 from pip; force in case cmake3 already exists
+# cmake-3.28.4 from pip; force in case cmake3 already exists
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.18.4.post1 && \
+    python3 -mpip install cmake==3.28.4 && \
     ln -sf /usr/local/bin/cmake /usr/bin/cmake3
 
 FROM cpu_final as cuda_final

--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -128,6 +128,7 @@ ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/op
 
 # cmake-3.28.4 from pip; force in case cmake3 already exists
 RUN yum install -y python3-pip && \
+    python3 -m pip install --upgrade pip && \
     python3 -mpip install cmake==3.28.4 && \
     ln -sf /usr/local/bin/cmake /usr/bin/cmake3
 


### PR DESCRIPTION
## Motivation

Cmake 3.18.4 is not available on pypi anymore

## Technical Details

Use newer version of cmake: 3.28.4

## Test Plan

https://rocm-ci.amd.com/job/pytorch-manylinux-wheel-builder_rel-7.2/389/

## Test Result

Manylinux docker image build passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
