### PR TITLE
[rocm7.2] Drop missing cp313-cp313t from setuptools/wheel install loop

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -12,7 +12,11 @@ RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl 
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 # Install setuptools and wheel for python 3.12/3.13
-RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
+# Note: cp313-cp313t (free-threaded 3.13) was dropped from the upstream
+# manylinux_2_28_x86_64 image; the free-threaded interpreter ships under
+# cp314-cp314t / cp315-cp315t now. Iterating over a non-existent
+# /opt/python/cp313-cp313t/bin/python fails the build with exit 127.
+RUN for cpython_version in "cp312-cp312" "cp313-cp313"; do \
     /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
     done;
 


### PR DESCRIPTION
## Why

`manywheel/Dockerfile_2_28` aborts every wheel build at step 18:

```
#18 ERROR: process "/bin/sh -c for cpython_version in \"cp312-cp312\" \"cp313-cp313\" \"cp313-cp313t\"; do \
  /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; done;" did not complete successfully: exit code: 127
```

The pinned base image `quay.io/pypa/manylinux_2_28_x86_64@sha256:2147aade9c…` no longer ships `/opt/python/cp313-cp313t/` — free-threaded moved up to `cp314-cp314t`/`cp315-cp315t` with CPython.

## What

Drop `cp313-cp313t` from the loop. It's the only reference in the repo and no wheel matrix builds a `py3.13t` artifact.

## Test

Re-ran all four pytorch wheel jobs today with `BUILDER_BRANCH=jechrist/fix-cp313t-missing` and `FORCE_BUILD_AND_PUSH_MANYLINUX_IMAGE=1`. The patched Dockerfile_2_28 now builds and pushes `rocm/pytorch-private:manylinux-7.2-compute-rocm-rel-7.2-93` cleanly:

| Parent job | Wheel-builder | Manylinux image push |
|---|---|---|
| [pytorch2.7 #89](https://rocm-ci.amd.com/job/pytorch2.7-manylinux-wheels_rel-7.2/89/) | pwb #519 | 17:43 ✅ |
| [pytorch2.8 #85](https://rocm-ci.amd.com/job/pytorch2.8-manylinux-wheels_rel-7.2/85/) | pwb #516 | 17:34 ✅ |
| [pytorch2.9 #153](https://rocm-ci.amd.com/job/pytorch2.9-manylinux-wheels_rel-7.2/153/) | pwb #520 | 17:40 ✅ |
| [pytorch2.10 #62](https://rocm-ci.amd.com/job/pytorch2.10-manylinux-wheels_rel-7.2/62/) | pwb #515 | 17:18 ✅ |

Companion PR #106 lands the same fix on `main`.
