### PR TITLE
[main] Drop missing cp313-cp313t from setuptools/wheel install loop

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -12,7 +12,11 @@ RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl 
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 # Install setuptools and wheel for python 3.12/3.13
-RUN for cpython_version in "cp312-cp312" "cp313-cp313" "cp313-cp313t"; do \
+# Note: cp313-cp313t (free-threaded 3.13) was dropped from the upstream
+# manylinux_2_28_x86_64 image; the free-threaded interpreter ships under
+# cp314-cp314t / cp315-cp315t now. Iterating over a non-existent
+# /opt/python/cp313-cp313t/bin/python fails the build with exit 127.
+RUN for cpython_version in "cp312-cp312" "cp313-cp313"; do \
     /opt/python/${cpython_version}/bin/python -m pip install setuptools wheel; \
     done;
 


### PR DESCRIPTION
## Why

Same fix as #105, applied to `main`. Both branches carry the broken loop introduced in #66.

`manywheel/Dockerfile_2_28` aborts every wheel build at step 18:

```
#18 ERROR: ... cp313-cp313t ... did not complete successfully: exit code: 127
```

The pinned base image `quay.io/pypa/manylinux_2_28_x86_64@sha256:2147aade9c…` no longer ships `/opt/python/cp313-cp313t/`.

## What

Drop `cp313-cp313t` from the loop. It's the only reference in the repo.

## Test

Verified via #105 (rocm7.2): all four pytorch wheel jobs re-run today with the patched `Dockerfile_2_28` successfully build and push `rocm/pytorch-private:manylinux-7.2-compute-rocm-rel-7.2-93`.

Most directly relevant for this PR: [pytorch2.10 #62](https://rocm-ci.amd.com/job/pytorch2.10-manylinux-wheels_rel-7.2/62/) (`BUILDER_BRANCH=main` is what this branch will become; today's run used the rocm7.2-based fix branch, identical content for this file). Its wheel-builder pwb #515 reaches `naming to docker.io/rocm/pytorch-private:manylinux-7.2-compute-rocm-rel-7.2-93 done` at 17:18.
